### PR TITLE
Submit connection info on return key press

### DIFF
--- a/mod/APLastConnectInfo.cs
+++ b/mod/APLastConnectInfo.cs
@@ -9,6 +9,11 @@ namespace Archipelago
         public string host_name;
         public string slot_name;
         public string password;
+
+        public bool Valid
+        {
+            get => host_name != "" && slot_name != "";
+        }
         
         public static APLastConnectInfo LoadFromFile(string path)
         {

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -87,6 +87,12 @@ namespace Archipelago
                 GUI.Label(new Rect(16, 56, 150, 20), "PlayerName: ");
                 GUI.Label(new Rect(16, 76, 150, 20), "Password: ");
 
+                bool submit = false;
+                if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return)
+                {
+                    submit = true;
+                }
+
                 APState.ServerData.host_name = GUI.TextField(new Rect(150 + 16 + 8, 36, 150, 20), 
                     APState.ServerData.host_name);
                 APState.ServerData.slot_name = GUI.TextField(new Rect(150 + 16 + 8, 56, 150, 20), 
@@ -94,7 +100,13 @@ namespace Archipelago
                 APState.ServerData.password = GUI.TextField(new Rect(150 + 16 + 8, 76, 150, 20), 
                     APState.ServerData.password);
 
-                if (GUI.Button(new Rect(16, 96, 100, 20), "Connect"))
+                if (submit && Event.current.type == EventType.KeyDown)
+                {
+                    // The text fields have not consumed the event, which means they were not focused.
+                    submit = false;
+                }
+
+                if ((GUI.Button(new Rect(16, 96, 100, 20), "Connect") || submit) && APState.ServerData.Valid)
                 {
                     APState.Connect();
                 }


### PR DESCRIPTION
## Changes
* It has been bothering me that I couldn't submit the connection info form using the return key. This PR addresses that.
* To avoid people accidentally submitting the form after only entering the host name, I added a check that requires both host name and slot name to be filled.

## Has this been tested?
Yes, with particular focus on ensuring one does not accidentally submit the form when using the return key in other contexts (the console for example).

## Notes
My solution to detect whether the form has focus feels really janky, but then again all of IMGUI feels janky to me.