### PR TITLE
DataboxSpawner: Replicate asyncness of patch target properly

### DIFF
--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -412,10 +412,18 @@ namespace Archipelago
         [HarmonyPrefix]
         public static bool AlwaysSpawn(DataboxSpawner __instance, ref IEnumerator __result)
         {
-            __result = AddressablesUtility.InstantiateAsync(__instance.databoxPrefabReference.RuntimeKey as string, 
-                __instance.transform.parent, __instance.transform.localPosition, __instance.transform.localRotation);
-            Object.Destroy(__instance.gameObject);
+            __result = PatchedStart(__instance);
             return false;
+        }
+        
+        private static IEnumerator PatchedStart(DataboxSpawner __instance)
+        {
+            if (__instance.spawnTechType != 0)
+            {
+                yield return AddressablesUtility.InstantiateAsync(__instance.databoxPrefabReference.RuntimeKey as string,
+                    __instance.transform.parent, __instance.transform.localPosition, __instance.transform.localRotation);
+            }
+            Object.Destroy(__instance.gameObject);
         }
     }
 


### PR DESCRIPTION
## What is this fixing?
Since 684c09d, no data boxes spawn at all for me. As the code (as I understand it) may contain a race condition, this problem may not be affecting everyone all the time. I think nobody else complained about this issue yet, but for me it occurs 100% of the time.

## The solution
See title; I replicated the original `DataboxSpawner.Start` function more closely, such that `Object.Destroy` is never executed before the `InstantiateAsync` call has completed.

## Has this been tested?
Yes, on old and new multiworlds and saves, including saving and reloading, at three data box locations with four data boxes. I didn't observe any missing or duplicate data boxes (except for in damaged savegames).

## Savegames
This fix does not repair savegames. Any savegame that has loaded a cell with a data box location for the first time on the latest version will still be missing that data box.