### PR TITLE
Add ability to change whether vehicles are in or out of logic (or game).

### DIFF
--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -10,7 +10,6 @@ using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Packets;
-using BepInEx.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -62,7 +62,6 @@ namespace Archipelago
         public static string TrackedLocationName;
         public static float TrackedDistance;
         public static float TrackedAngle;
-        public static ManualLogSource Logger;
 
         public static ArchipelagoSession Session;
         public static ArchipelagoUI ArchipelagoUI = null;

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -286,7 +286,7 @@ namespace Archipelago
                     {
                         SeamothState = really_include_seamoth;
                     }
-                    Debug.Log("Seamoth State: " + SeamothState);
+                    Logging.LogDebug("Seamoth State: " + SeamothState);
                 }
                 if (loginSuccess.SlotData.TryGetValue("include_prawn", out var include_prawn))
                 {
@@ -294,7 +294,7 @@ namespace Archipelago
                     {
                         PrawnState = really_include_prawn;
                     }
-                    Debug.Log("Prawn State: " + PrawnState);
+                    Logging.LogDebug("Prawn State: " + PrawnState);
                 }
                 if (loginSuccess.SlotData.TryGetValue("include_cyclops", out var include_cyclops))
                 {
@@ -302,7 +302,7 @@ namespace Archipelago
                     {
                         CyclopsState = really_include_cyclops;
                     }
-                    Debug.Log("Cyclops State: " + CyclopsState);
+                    Logging.LogDebug("Cyclops State: " + CyclopsState);
                 }
                 Goal = (string)loginSuccess.SlotData["goal"];
                 GoalMapping.TryGetValue(Goal, out GoalEvent);
@@ -315,7 +315,7 @@ namespace Archipelago
                 }
 
 
-                Debug.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData));
+                Logging.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData), ingame:false);
                 ServerConnectInfo.death_link = Convert.ToInt32(loginSuccess.SlotData["death_link"]) > 0;
                 set_deathlink();
 

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -230,7 +230,7 @@ namespace Archipelago
                 }
                 else
                 {
-                    Debug.LogError("Could not write most recent connect info to file.");
+                    Logging.LogError("Could not write most recent connect info to file.");
                 }
                 
                 Authenticated = true;
@@ -254,7 +254,7 @@ namespace Archipelago
                 }
                     
                 
-                Debug.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData));
+                Logging.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData), ingame:false);
                 ServerConnectInfo.death_link = Convert.ToInt32(loginSuccess.SlotData["death_link"]) > 0;
                 set_deathlink();
 
@@ -262,23 +262,21 @@ namespace Archipelago
             else if (loginResult is LoginFailure loginFailure)
             {
                 Authenticated = false;
-                Debug.LogError(String.Join("\n", loginFailure.Errors));
+                Logging.LogError("Connection Error: " + String.Join("\n", loginFailure.Errors));
                 Session = null;
-                ErrorMessage.AddMessage("Connection Error: " + String.Join("\n", loginFailure.Errors));
             }
             // all fragments
             TechFragmentsToDestroy = new HashSet<TechType>(APState.tech_fragments);
             // remove vanilla so it's scannable
             TechFragmentsToDestroy.ExceptWith(vanillaTech);
-            Debug.LogError("Preventing scanning of: " + string.Join(", ", TechFragmentsToDestroy));
-            Debug.LogError("Allowing scanning of: " + string.Join(", ", vanillaTech));
+            Logging.LogDebug("Preventing scanning of: " + string.Join(", ", TechFragmentsToDestroy));
+            Logging.LogDebug("Allowing scanning of: " + string.Join(", ", vanillaTech));
             return loginResult.Successful;
         }
         
         static void Session_SocketClosed(string reason)
         {
-            message_queue.Add("Connection to Archipelago lost: " + reason);
-            Debug.LogError("Connection to Archipelago lost: " + reason);
+            Logging.LogError("Connection to Archipelago lost: " + reason);
             Disconnect();
         }
         static void Session_MessageReceived(LogMessage message)
@@ -290,8 +288,8 @@ namespace Archipelago
         }
         static void Session_ErrorReceived(Exception e, string message)
         {
-            Debug.LogError(message);
-            if (e != null) Debug.LogError(e.ToString());
+            Logging.LogError(message);
+            if (e != null) Logging.LogError(e.ToString());
             Disconnect();
         }
 
@@ -310,7 +308,7 @@ namespace Archipelago
         {
             if (!(bool) (UnityEngine.Object) Player.main.liveMixin)
                 return;
-            Debug.Log("Received DeathLink");
+            Logging.LogDebug("Received DeathLink");
             DeathLinkKilling = true;
             Player.main.liveMixin.Kill();
             message_queue.Add(deathLink.Cause);
@@ -364,7 +362,7 @@ namespace Archipelago
 
         public static void Resync()
         {
-            Debug.Log("Running Item resync with " + Session.Items.AllItemsReceived.Count + " items.");
+            Logging.LogDebug("Running Item resync with " + Session.Items.AllItemsReceived.Count + " items.");
             var done = new HashSet<long>();
             for (int i = 0; i < Session.Items.AllItemsReceived.Count; i++)
             {
@@ -505,7 +503,7 @@ namespace Archipelago
             GameObject gameObject = prefabResult.Get();
             if (gameObject == null)
             {
-                Debug.LogError("Object " + techType + " failed to be created.");
+                Logging.LogError("Object " + techType + " failed to be created.", ingame:false);
                 yield break;
             }
             // in case it can't be picked up, dump it right in front of player for obvious problem.
@@ -517,7 +515,7 @@ namespace Archipelago
             Pickupable pickupable = gameObject.GetComponent<Pickupable>();
             if (pickupable == null)
             {
-                Debug.LogError("Object " + techType + " was not pickupable.");
+                Logging.LogError("Object " + techType + " was not pickupable.", ingame:false);
                 UnityEngine.Object.Destroy(gameObject);
             }
             else

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -31,6 +31,13 @@ namespace Archipelago
             InGame
         }
 
+        public enum Inclusion
+        {
+            Included,
+            NotInLogic,
+            Excluded
+        }
+
         public static Dictionary<string, string> GoalMapping = new Dictionary<string, string>()
         {
             { "free", "Goal_Disable_Gun" },
@@ -51,6 +58,11 @@ namespace Archipelago
         public static string Goal = "launch";
         public static string GoalEvent = "";
         public static string SwimRule = "";
+        public static float SwimDepth = 0f;
+        public static bool ItemsRelevant = true;
+        public static Inclusion SeamothState = Inclusion.Included;
+        public static Inclusion PrawnState = Inclusion.Included;
+        public static Inclusion CyclopsState = Inclusion.Included;
         public static bool FreeSamples;
         public static bool Silent = false;
         public static Thread TrackerProcessing;
@@ -236,10 +248,61 @@ namespace Archipelago
                 if (loginSuccess.SlotData.TryGetValue("swim_rule", out var swim_rule))
                 {
                     SwimRule = (string)swim_rule;
+                    if (SwimRule.Length == 0)
+                    {
+                        // assume most permissive logic if none given
+                        SwimRule = "items_hard";
+                    }
+                    var nameParts = SwimRule.Split('_');
+                    ItemsRelevant = nameParts.Length > 1;
+
+                    switch (nameParts.GetLast())
+                    {
+                        case "easy":
+                        {
+                            SwimDepth = 200f;
+                            break;
+                        }
+                        case "normal":
+                        {
+                            SwimDepth = 400f;
+                            break;
+                        }
+                        case "hard":
+                        {
+                            SwimDepth = 600f;
+                            break;
+                        }
+                    }
                 }
                 if (loginSuccess.SlotData.TryGetValue("free_samples", out var free_samples))
                 {
                     FreeSamples = Convert.ToInt32(free_samples) > 0;
+                }
+                if (loginSuccess.SlotData.TryGetValue("include_seamoth", out var include_seamoth))
+                {
+                    // This convoluted mess... works. It only has to run on load, so... good enough for now.
+                    if (Enum.TryParse(include_seamoth.ToString(), true, out Inclusion really_include_seamoth))
+                    {
+                        SeamothState = really_include_seamoth;
+                    }
+                    Debug.Log("Seamoth State: " + SeamothState);
+                }
+                if (loginSuccess.SlotData.TryGetValue("include_prawn", out var include_prawn))
+                {
+                    if (Enum.TryParse(include_prawn.ToString(), true, out Inclusion really_include_prawn))
+                    {
+                        PrawnState = really_include_prawn;
+                    }
+                    Debug.Log("Prawn State: " + PrawnState);
+                }
+                if (loginSuccess.SlotData.TryGetValue("include_cyclops", out var include_cyclops))
+                {
+                    if (Enum.TryParse(include_cyclops.ToString(), true, out Inclusion really_include_cyclops))
+                    {
+                        CyclopsState = really_include_cyclops;
+                    }
+                    Debug.Log("Cyclops State: " + CyclopsState);
                 }
                 Goal = (string)loginSuccess.SlotData["goal"];
                 GoalMapping.TryGetValue(Goal, out GoalEvent);
@@ -250,8 +313,8 @@ namespace Archipelago
                         vanillaTech.Add((TechType)Enum.Parse(typeof(TechType), tech.ToString()));
                     }
                 }
-                    
-                
+
+
                 Debug.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData));
                 ServerConnectInfo.death_link = Convert.ToInt32(loginSuccess.SlotData["death_link"]) > 0;
                 set_deathlink();

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -39,7 +39,7 @@ namespace Archipelago
             { "infected", "Infection_Progress4" },
         };
         
-        public static int[] AP_VERSION = new int[] { 0, 4, 1 };
+        public static int[] AP_VERSION = new int[] { 0, 5, 0 };
         public static APConnectInfo ServerConnectInfo = new APConnectInfo();
         public static DeathLinkService DeathLinkService = null;
         public static bool DeathLinkKilling = false; // indicates player is currently getting DeathLinked
@@ -368,7 +368,7 @@ namespace Archipelago
             var done = new HashSet<long>();
             for (int i = 0; i < Session.Items.AllItemsReceived.Count; i++)
             {
-                var itemID = Session.Items.AllItemsReceived[i].Item;
+                var itemID = Session.Items.AllItemsReceived[i].ItemId;
                 if (ArchipelagoData.ItemCodeToItemType[itemID] == ArchipelagoItemType.Resource || !done.Contains(itemID))
                 {
                     Unlock(itemID, i);
@@ -431,7 +431,7 @@ namespace Archipelago
 
                 if (entry != null)
                 {
-                    int newCount = Session.Items.AllItemsReceived.Count(networkItem => networkItem.Item == apItemID);
+                    int newCount = Session.Items.AllItemsReceived.Count(networkItem => networkItem.ItemId == apItemID);
                     if (newCount == entry.unlocked)
                     {
                         return;

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -10,6 +10,7 @@ using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Packets;
+using BepInEx.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -61,6 +62,7 @@ namespace Archipelago
         public static string TrackedLocationName;
         public static float TrackedDistance;
         public static float TrackedAngle;
+        public static ManualLogSource Logger;
 
         public static ArchipelagoSession Session;
         public static ArchipelagoUI ArchipelagoUI = null;

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -10,7 +10,6 @@ using Archipelago.MultiClient.Net.Packets;
 using System.Text;
 using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Newtonsoft.Json;
-using Debug = UnityEngine.Debug;
 using File = System.IO.File;
 using Object = UnityEngine.Object;
 
@@ -817,6 +816,32 @@ namespace Archipelago
         }
     }
 
+    [HarmonyPatch(typeof(Player))]
+    [HarmonyPatch("Start")]
+    internal class PlayerStartPatch
+    {
+        [HarmonyPostfix]
+        public static void PatchPlayerOxygenTank(Player __instance)
+        {
+            Inventory.main.equipment.onEquip += EquipmentChanged;
+        }
+        private static void EquipmentChanged(string slot, InventoryItem item)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            Oxygen component = item.item.GetComponent<Oxygen>();
+            if (component == null)
+            {
+                return;
+            }
+            // prevent cheating logic by swapping between oxygen tanks
+            component.RemoveOxygen(component.oxygenCapacity);
+        }
+    }
+    
 #if DEBUG
     [HarmonyPatch(typeof(GUIHand))]
     [HarmonyPatch("OnUpdate")]

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -598,11 +598,15 @@ namespace Archipelago
         [HarmonyPrefix]
         public static void InitializeOverride(object owner, object state)
         {
-            APState.Logger.LogInfo("Begin Patching savePath.");
+            
             var storage = owner as UserStoragePC;
             var rawPath = storage.GetType().GetField("savePath",
                 BindingFlags.NonPublic | BindingFlags.Instance).GetValue(storage) as string;
-
+            if (rawPath.Contains("ArchipelagoSaves"))
+            {
+                // feels kind of dirty, but so does initialize running multiple times.
+                return;
+            }
             APState.Logger.LogInfo($"Original SavePath: " + rawPath);
             rawPath = Platform.IO.Path.Combine(rawPath, "ArchipelagoSaves");
             if (rawPath != null)

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -131,36 +131,38 @@ namespace Archipelago
                     GUI.Label(new Rect(16, 36, 1000, 20), text);
                 }
 
+                int showing_fish = 0;
                 if (APState.TrackedFishCount > 0 && APState.TrackedMode != TrackerMode.Disabled)
                 {
-                    GUI.Label(new Rect(16, 56, 1000, 22), 
+                    showing_fish = 1;
+                    GUI.Label(new Rect(16, 56, 1000, 22),
                         "Fish left: "+APState.TrackedFishCount + ". Such as: "+APState.TrackedFish);
                 }
-                
+
                 if (PlayerNearStart())
                 {
-                    GUI.Label(new Rect(16, 76, 1000, 22), 
+                    GUI.Label(new Rect(16, 56 + showing_fish * 20, 1000, 22),
                         "Goal: "+APState.Goal);
                     if (APState.SwimRule.Length == 0)
                     {
-                        GUI.Label(new Rect(16, 96, 1000, 22), 
-                            "No Swim Rule sent by Server. Assuming items_hard." + 
-                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth + 
+                        GUI.Label(new Rect(16, 76 + showing_fish * 20, 1000, 22),
+                            "No Swim Rule sent by Server. Assuming items_hard." +
+                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth +
                                                           TrackerThread.LogicVehicleDepth));
                     }
                     else
                     {
-                        GUI.Label(new Rect(16, 96, 1000, 22), 
+                        GUI.Label(new Rect(16, 76 + showing_fish * 20, 1000, 22),
                             "Swim Rule: "+APState.SwimRule +
-                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth + 
-                                                          TrackerThread.LogicVehicleDepth) + 
-                            " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth + 
+                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth +
+                                                          TrackerThread.LogicVehicleDepth) +
+                            " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth +
                             " (" + TrackerThread.LogicVehicle + ")");
                     }
                 }
                 if (!APState.TrackerProcessing.IsAlive)
                 {
-                    GUI.Label(new Rect(16, 116, 1000, 22), 
+                    GUI.Label(new Rect(16, 96 + showing_fish * 20, 1000, 22),
                         "Error: Tracker Thread died. Tracker will not update.");
                 }
             }
@@ -563,7 +565,112 @@ namespace Archipelago
         }
     }
 #endif
-    
+
+    /* The next 3x patches graft the Cyclops Shield Module onto
+       the Moonpool Fabricator if the goal is launch but the Cyclops is not in game */
+    [HarmonyPatch(typeof(CraftTree))]
+    [HarmonyPatch("SeamothUpgradesScheme")]
+    internal class MoonpoolFabricator
+    {
+        [HarmonyPrefix]
+        public static bool AdditionalShieldGenerator(ref CraftNode __result)
+        {
+            if (APState.state != APState.State.InGame)
+            {
+                return true;
+            }
+
+            // We only need to run this if the Cyclops isn't in game and we're trying to goal
+            if (APState.CyclopsState != APState.Inclusion.Excluded || APState.Goal != "launch")
+            {
+                return true;
+            }
+
+            __result = new CraftNode("Root").AddNode(
+                new CraftNode("CommonModules", TreeAction.Expand).AddNode(
+                    new CraftNode("VehicleArmorPlating", TreeAction.Craft, TechType.VehicleArmorPlating),
+                    new CraftNode("VehiclePowerUpgradeModule", TreeAction.Craft, TechType.VehiclePowerUpgradeModule),
+                    new CraftNode("VehicleStorageModule", TreeAction.Craft, TechType.VehicleStorageModule)
+                ),
+                new CraftNode("SeamothModules", TreeAction.Expand).AddNode(
+                    new CraftNode("VehicleHullModule1", TreeAction.Craft, TechType.VehicleHullModule1),
+                    new CraftNode("SeamothSolarCharge", TreeAction.Craft, TechType.SeamothSolarCharge),
+                    new CraftNode("SeamothElectricalDefense", TreeAction.Craft, TechType.SeamothElectricalDefense),
+                    new CraftNode("SeamothTorpedoModule", TreeAction.Craft, TechType.SeamothTorpedoModule),
+                    new CraftNode("SeamothSonarModule", TreeAction.Craft, TechType.SeamothSonarModule)
+                ),
+                new CraftNode("ExosuitModules", TreeAction.Expand).AddNode(
+                    new CraftNode("ExoHullModule1", TreeAction.Craft, TechType.ExoHullModule1),
+                    new CraftNode("ExosuitThermalReactorModule", TreeAction.Craft, TechType.ExosuitThermalReactorModule),
+                    new CraftNode("ExosuitJetUpgradeModule", TreeAction.Craft, TechType.ExosuitJetUpgradeModule),
+                    new CraftNode("ExosuitPropulsionArmModule", TreeAction.Craft, TechType.ExosuitPropulsionArmModule),
+                    new CraftNode("ExosuitGrapplingArmModule", TreeAction.Craft, TechType.ExosuitGrapplingArmModule),
+                    new CraftNode("ExosuitDrillArmModule", TreeAction.Craft, TechType.ExosuitDrillArmModule),
+                    new CraftNode("ExosuitTorpedoArmModule", TreeAction.Craft, TechType.ExosuitTorpedoArmModule)
+                ),
+                new CraftNode("Torpedoes", TreeAction.Expand).AddNode(
+                    new CraftNode("WhirlpoolTorpedo", TreeAction.Craft, TechType.WhirlpoolTorpedo),
+                    new CraftNode("GasTorpedo", TreeAction.Craft, TechType.GasTorpedo)
+                ),
+                new CraftNode("CyclopsModules", TreeAction.Expand).AddNode(
+                    new CraftNode("CyclopsShieldModule", TreeAction.Craft, TechType.CyclopsShieldModule)
+                )
+            );
+
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(Language))]
+    [HarmonyPatch("Get")]
+    internal class MoonpoolFabricator_CraftNodeText
+    {
+        [HarmonyPrefix]
+        public static bool RewriteCraftNodeText(ref string __result, string key)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return true;
+            }
+
+            // This is our own made-up string, it won't match anything else.
+            if (key == "SeamothUpgradesMenu_CyclopsModules")
+            {
+                // Use a built-in replacement so it's translated properly for us
+                // comes out as "Cyclops Upgrades" (there is no "Cyclops modules" translated string)
+                __result = Language.main.Get("TechCategoryCyclopsUpgrades");
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(SpriteManager))]
+    [HarmonyPatch("Get")]
+    [HarmonyPatch(new Type[] { typeof(SpriteManager.Group), typeof(string) })]
+    internal class MoonpoolFabricator_CraftNodeIcon
+    {
+        [HarmonyPrefix]
+        public static bool RewriteCraftNodeIcon(ref Atlas.Sprite __result, SpriteManager.Group group, string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return true;
+            }
+
+            // our made-up string, which otherwise returns the default (question-mark) icon
+            if (name == "SeamothUpgrades_CyclopsModules")
+            {
+                // This sprite comes from the vehicle fabricator
+                __result = SpriteManager.Get(TechType.Cyclops);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
     [HarmonyPatch(typeof(MainGameController))]
     [HarmonyPatch("LoadInitialInventoryAsync")]
     internal class MainGameController_LoadInitialInventoryAsync_Patch

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -769,13 +769,13 @@ namespace Archipelago
             if (APState.message_dequeue_timeout <= 0.0f)
             {
                 // We only do x at a time. To not crowd the on screen log/events too fast
-                List<string> to_process = new List<string>();
-                while (to_process.Count < dequeueCount && APState.message_queue.Count > 0)
+                List<string> toProcess = new List<string>();
+                while (toProcess.Count < dequeueCount && APState.message_queue.Count > 0)
                 {
-                    to_process.Add(APState.message_queue[0]);
+                    toProcess.Add(APState.message_queue[0]);
                     APState.message_queue.RemoveAt(0);
                 }
-                foreach (var message in to_process)
+                foreach (var message in toProcess)
                 {
                     ErrorMessage.AddMessage(message);
                 }
@@ -788,7 +788,7 @@ namespace Archipelago
                 if (APState.ServerConnectInfo.index < APState.Session.Items.AllItemsReceived.Count)
                 {
                     APState.Unlock(APState.Session.Items.AllItemsReceived[
-                        Convert.ToInt32(APState.ServerConnectInfo.index)].Item, APState.ServerConnectInfo.index);
+                        Convert.ToInt32(APState.ServerConnectInfo.index)].ItemId, APState.ServerConnectInfo.index);
                     APState.ServerConnectInfo.index++;
                     // We only do x at a time. To not crowd the on screen log/events too fast
                     APState.unlock_dequeue_timeout = dequeueTime;

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -57,7 +57,7 @@ namespace Archipelago
             {
                 if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C))
                 {
-                    Debug.Log("INSPECT GAME OBJECT: " + mouse_target_desc);
+                    Logging.Log("INSPECT GAME OBJECT: " + mouse_target_desc, ingame:false);
                     string id = mouse_target_desc.Split(new char[] { ':' })[0];
                     GUIUtility.systemCopyBuffer = id;
                     copied_fade = 1.0f;
@@ -69,6 +69,7 @@ namespace Archipelago
 
         void OnGUI()
         {
+            Logging.TryUpdateLog();
 #if DEBUG
             GUI.Box(new Rect(0, 0, Screen.width, 120), "");
 #endif
@@ -305,8 +306,7 @@ namespace Archipelago
             }
             else
             {
-                Debug.Log("Can only 'say' while connected to Archipelago.");
-                ErrorMessage.AddMessage("Can only 'say' while connected to Archipelago.");
+                Logging.Log("Can only 'say' while connected to Archipelago.");
             }
         }
         private void OnConsoleCommand_silent(NotificationCenter.Notification n)
@@ -315,14 +315,12 @@ namespace Archipelago
             
             if (APState.Silent)
             {
-                Debug.Log("Muted Archipelago chat.");
-                ErrorMessage.AddMessage("Muted Archipelago chat.");
+                Logging.Log("Muted Archipelago chat.");
                 APState.message_queue.Clear();
             }
             else
             {
-                Debug.Log("Enabled Archipelago chat.");
-                ErrorMessage.AddMessage("Enabled Archipelago chat.");
+                Logging.Log("Enabled Archipelago chat.");
             }
         }
         private void OnConsoleCommand_tracker(NotificationCenter.Notification n)
@@ -331,18 +329,15 @@ namespace Archipelago
             {
                 case TrackerMode.Disabled:
                     APState.TrackedMode = TrackerMode.Closest;
-                    Debug.Log("Tracking Locations by proximity.");
-                    ErrorMessage.AddMessage("Tracking Locations by proximity.");
+                    Logging.Log("Tracking Locations by proximity.");
                     break;
                 case TrackerMode.Closest:
                     APState.TrackedMode = TrackerMode.Logical;
-                    Debug.Log("Tracking Locations by proximity and filtering by logic");
-                    ErrorMessage.AddMessage("Tracking Locations by proximity and filtering by logic");
+                    Logging.Log("Tracking Locations by proximity and filtering by logic");
                     break;
                 case TrackerMode.Logical:
                     APState.TrackedMode = TrackerMode.Disabled;
-                    Debug.Log("Location tracking disabled.");
-                    ErrorMessage.AddMessage("Location tracking disabled.");
+                    Logging.Log("Location tracking disabled.");
                     break;
             }
         }
@@ -353,13 +348,11 @@ namespace Archipelago
             
             if (APState.ServerConnectInfo.death_link)
             {
-                Debug.Log("Enabled DeathLink.");
-                ErrorMessage.AddMessage("Enabled DeathLink.");
+                Logging.Log("Enabled DeathLink.");
             }
             else
             {
-                Debug.Log("Disabled DeathLink.");
-                ErrorMessage.AddMessage("Disabled DeathLink.");
+                Logging.Log("Disabled DeathLink.");
             }
         }
         
@@ -367,16 +360,13 @@ namespace Archipelago
         {
             if (APState.state == APState.State.InGame)
             {
-                Debug.Log("Beginning Item resync.");
-                ErrorMessage.AddMessage("Beginning Item resync.");
+                Logging.Log("Beginning Item resync.");
                 APState.Resync();
-                Debug.Log("Item resync completed.");
-                ErrorMessage.AddMessage("Item resync completed.");
+                Logging.Log("Item resync completed.");
             }
             else
             {
-                Debug.Log("Cannot resync in menu.");
-                ErrorMessage.AddMessage("Cannot resync in menu.");
+                Logging.Log("Cannot resync in menu.");
             }
         }
         
@@ -650,14 +640,10 @@ namespace Archipelago
                 using (StreamReader reader = new StreamReader(path))
                 {
                     APState.ServerConnectInfo = JsonConvert.DeserializeObject<APConnectInfo>(reader.ReadToEnd());
-                    
-                    if (APState.Connect() && APState.ServerConnectInfo.@checked != null)
+                    var connected = APState.Connect();
+                    if (connected && APState.ServerConnectInfo.@checked != null)
                     {
                         APState.Session.Locations.CompleteLocationChecks(APState.ServerConnectInfo.@checked.ToArray());
-                    }
-                    else
-                    {
-                        ErrorMessage.AddError("Null Checked");
                     }
                 }
             }
@@ -715,7 +701,7 @@ namespace Archipelago
                     }
                     catch (Exception e)
                     {
-                        Debug.Log("archipelago_item_index error: " + e.Message);
+                        Logging.LogError("archipelago_item_index error: " + e.Message, ingame:false);
                     }
                 }
             }

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -870,6 +870,8 @@ namespace Archipelago
             {
                 case TechType.RadiationSuit:
                 case TechType.BaseLargeRoom:
+                case TechType.PrecursorIonBattery:
+                case TechType.PrecursorIonPowerCell:
                     return false;
                 default:
                     return true;

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -597,13 +597,13 @@ namespace Archipelago
                 // feels kind of dirty, but so does initialize running multiple times.
                 return;
             }
-            APState.Logger.LogInfo($"Original SavePath: " + rawPath);
+            Logging.Log($"Original SavePath: " + rawPath, ingame:false);
             rawPath = Platform.IO.Path.Combine(rawPath, "ArchipelagoSaves");
             if (rawPath != null)
             {
                 storage.GetType().GetField("savePath",
                     BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(storage, rawPath);
-                APState.Logger.LogInfo($"Changed SavePath: " + rawPath);
+                Logging.Log($"Changed SavePath: " + rawPath, ingame:false);
                 Directory.CreateDirectory(rawPath);
             }
         }

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.2.0" />
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Archipelago.MultiClient.Net" Version="5.0.6" />
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.1.1" />
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.0.1" />
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="6.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/mod/Logging.cs
+++ b/mod/Logging.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using UnityEngine;
+
+namespace Archipelago;
+// Unity logging is documented as thread safe, but it's not.
+// So this is my own wrapper around it so it doesn't just silently fail.
+public static class Logging
+{
+    public static Thread MainThread = null;
+    public static ConcurrentQueue<Tuple<string, bool>> UnityLogQueue = new ConcurrentQueue<Tuple<string, bool>>();
+
+    public static void Initialize()
+    {
+        MainThread = Thread.CurrentThread;
+    }
+
+    public static void Log(string message, bool ingame = true, bool unity_log = true, bool is_error = false)
+    {
+        if (ingame)
+        {
+            ErrorMessage.AddMessage(message);
+        }
+
+        if (unity_log)
+        {
+            UnityLogQueue.Enqueue(new Tuple<string, bool>(message, is_error));
+        }
+
+        TryUpdateLog();
+    }
+
+    public static void LogDebug(string message)
+    {
+        Log(message, ingame:false, unity_log:true, is_error:false);
+    }
+    
+    public static void LogError(string message, bool ingame = true, bool unity_log = true)
+    {
+        Log(message, ingame, unity_log, is_error:true);
+    }
+    
+    public static bool TryUpdateLog()
+    {
+        if (Thread.CurrentThread == MainThread)
+        {
+            Tuple<string, bool> nextText;
+            while (true)
+            {
+                bool success = UnityLogQueue.TryDequeue(out nextText);
+                if (!success)
+                {
+                    return true;
+                }
+
+                if (nextText.Item2)
+                {
+                    Debug.LogError(nextText.Item1);
+                }
+                else
+                {
+                    Debug.Log(nextText.Item1);
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -19,6 +19,7 @@ namespace Archipelago
         private void Awake()
         {
             var harmony = new Harmony("Archipelago");
+            Logging.Initialize();
             ArchipelagoData.Init();
             APState.Logger = Logger;
             
@@ -32,7 +33,8 @@ namespace Archipelago
             {
                 Zero = true;
             }
-            Debug.Log("Archipelago: Below Zero: " + Zero);
+            Logging.Log("Archipelago: Below Zero: " + Zero, ingame:false);
+
             // Universal Patches
             harmony.PatchAll(Assembly.GetExecutingAssembly());
             // Manual Patching based on game 
@@ -48,9 +50,9 @@ namespace Archipelago
             harmony.Patch(typeof(PDAEncyclopedia).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Static),
                 postfix: new HarmonyMethod(typeof(CustomPDA).GetMethod("Add")));
             
-            Logger.LogInfo($"Plugin Archipelago (" + Version + ") for Server (" 
-                           + APState.AP_VERSION[0] + "." + APState.AP_VERSION[1] + "." + APState.AP_VERSION[2] + 
-                           ") is loaded!");
+            Logging.Log($"Plugin Archipelago (" + Version + ") for Server (" 
+                        + APState.AP_VERSION[0] + "." + APState.AP_VERSION[1] + "." + APState.AP_VERSION[2] + 
+                        ") is loaded!", ingame:false);
         }
 
         private void PatchSubnautica(Harmony harmony)

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using System.Threading;
 using BepInEx;
 using HarmonyLib;
-using UnityEngine;
 
 namespace Archipelago
 {

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -10,7 +10,7 @@ namespace Archipelago
     [BepInPlugin("Archipelago", "Archipelago", Version)]
     public class ArchipelagoPlugin : BaseUnityPlugin
     {
-        public const string Version = "1.8.0";
+        public const string Version = "1.8.1";
         public static bool Zero;
         // Early Reflection to not fish for things later:
         public static Type SubnauticaEscapePod;

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -20,6 +20,8 @@ namespace Archipelago
         {
             var harmony = new Harmony("Archipelago");
             ArchipelagoData.Init();
+            APState.Logger = Logger;
+            
             // launch tracker thread
             APState.TrackerProcessing = new Thread(TrackerThread.DoWork);
             APState.TrackerProcessing.IsBackground = true;

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -11,7 +11,7 @@ namespace Archipelago
     [BepInPlugin("Archipelago", "Archipelago", Version)]
     public class ArchipelagoPlugin : BaseUnityPlugin
     {
-        public const string Version = "1.7.1";
+        public const string Version = "1.8.0";
         public static bool Zero;
         // Early Reflection to not fish for things later:
         public static Type SubnauticaEscapePod;

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -21,7 +21,6 @@ namespace Archipelago
             var harmony = new Harmony("Archipelago");
             Logging.Initialize();
             ArchipelagoData.Init();
-            APState.Logger = Logger;
             
             // launch tracker thread
             APState.TrackerProcessing = new Thread(TrackerThread.DoWork);

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -12,30 +12,27 @@ namespace Archipelago
         Closest,
         Logical,
     }
-    
+
     public class TrackerThread
     {
         public static string DepthString = "";
         public static bool ItemsRelevant = true;
         public static float BaseDepth = 600f;
         public static float LogicSwimDepth = BaseDepth;
+        public static float TheoreticalSeamothDepth = BaseDepth;
+        public static bool IncludeSeamoth = true;
+        public static bool IncludePrawn = true;
+        public static bool IncludeCyclops = true;
         public static float LogicVehicleDepth = 0;
         public static string LogicVehicle = "Vehicle";
+        public static long creatureScanCutOff = 33999;
+
         public static bool InLogic(long locID)
         {
             // Gating items
             foreach (var logic in ArchipelagoData.LogicDict)
             {
-                bool hasItem;
-                try
-                {
-                    hasItem = KnownTech.Contains(logic.Key);
-                }
-                catch (NullReferenceException)
-                {
-                    hasItem = false;
-                }
-                
+                bool hasItem = KnownTech.Contains(logic.Key);
                 if (!hasItem && logic.Value.Contains(locID))
                 {
                     return false;
@@ -47,173 +44,296 @@ namespace Archipelago
 
         public static void PrimeDepthSystem()
         {
+            DepthString    = APState.SwimRule;
+            BaseDepth      = APState.SwimDepth;
+            ItemsRelevant  = APState.ItemsRelevant;
+            IncludeSeamoth = APState.SeamothState == APState.Inclusion.Included;
+            IncludePrawn   = APState.PrawnState == APState.Inclusion.Included;
+            IncludeCyclops = APState.CyclopsState == APState.Inclusion.Included;
 
-            DepthString = APState.SwimRule;
-            if (DepthString.Length == 0)
+            TheoreticalSeamothDepth = BaseDepth;
+            if (IncludeSeamoth)
             {
-                // assume most permissive logic if none given
-                DepthString = "items_hard";
-            }
-
-            var nameParts = DepthString.Split('_');
-
-            ItemsRelevant = nameParts.Length > 1;
-            switch (nameParts.GetLast())
-            {
-                case "easy":
-                {
-                    BaseDepth = 200f;
-                    break;
-                }
-                case "normal":
-                {
-                    BaseDepth = 400f;
-                    break;
-                }
-                case "hard":
-                {
-                    BaseDepth = 600f;
-                    break;
-                }
+                TheoreticalSeamothDepth = getTheoreticalLogicDepth(900f);
             }
         }
 
-        public static void UpdateLogicDepth()
+        public static float getTheoreticalLogicDepth(float candidateVehicleDepth)
         {
-            float swimdepth = BaseDepth;
-            bool hasModStation;
-            try
+            float coreDepth = BaseDepth + candidateVehicleDepth;
+            if (ItemsRelevant)
             {
-                hasModStation = KnownTech.Contains(TechType.Workbench);
+                return coreDepth + 350f;
             }
-            catch (NullReferenceException)
+
+            return coreDepth;
+        }
+
+        public static float GetLogicDepth()
+        {
+            float itemdepth = 0;
+
+            if (! ItemsRelevant)
             {
-                return;
+                return itemdepth;
             }
+
+            bool hasModStation = KnownTech.Contains(TechType.Workbench);
 
             if (KnownTech.Contains(TechType.Seaglide))
             {
-                swimdepth += 200f;
+                itemdepth += 200f;
                 // Ultra High Capacity Tank
                 if (hasModStation && KnownTech.Contains(TechType.HighCapacityTank))
                 {
-                    swimdepth += 150f;
+                    itemdepth += 150f;
                 }
             }
             else if (hasModStation && KnownTech.Contains(TechType.UltraGlideFins))
             {
-                swimdepth += 50f;
+                itemdepth += 50f;
                 if (KnownTech.Contains(TechType.HighCapacityTank))
                 {
-                    swimdepth += 100f;
+                    itemdepth += 100f;
                 }
                 else if (KnownTech.Contains(TechType.PlasteelTank))
                 {
-                    swimdepth += 25f;
+                    itemdepth += 25f;
                 }
             }
             else if (hasModStation && KnownTech.Contains(TechType.HighCapacityTank))
             {
-                swimdepth += 100f;
+                itemdepth += 100f;
             }
             else if (hasModStation && KnownTech.Contains(TechType.PlasteelTank))
             {
-                swimdepth += 25f;
+                itemdepth += 25f;
             }
 
-            LogicSwimDepth = swimdepth;
+            return itemdepth;
         }
 
-        public static void UpdateVehicleDepth()
+        public static int getSeamothDepth(bool has_mod, bool has_upg)
         {
-            bool hasBay;
+            if (! (IncludeSeamoth && KnownTech.Contains(TechType.Seamoth)))
+            {
+                return 0;
+            }
+
+            int depth = 200;
+            if (has_upg && KnownTech.Contains(TechType.VehicleHullModule1))
+            {
+                depth = 300;
+                if (has_mod && KnownTech.Contains(TechType.VehicleHullModule2))
+                {
+                    depth = 500;
+                    if (KnownTech.Contains(TechType.VehicleHullModule3))
+                    {
+                        depth = 900;
+                    }
+                }
+            }
+
+            return depth;
+        }
+
+        public static int getPrawnDepth(bool has_mod, bool has_upg)
+        {
+            if (! (IncludePrawn && KnownTech.Contains(TechType.Exosuit)))
+            {
+                return 0;
+            }
+
+            int depth = 900;
+            if (has_upg && KnownTech.Contains(TechType.ExoHullModule1))
+            {
+                depth = 1300;
+                if (has_mod && KnownTech.Contains(TechType.ExoHullModule2))
+                {
+                    depth = 1700;
+                }
+            }
+
+            return depth;
+        }
+
+        public static int getCyclopsDepth(bool has_mod, bool has_upg)
+        {
+            if (! (IncludeCyclops && KnownTech.Contains(TechType.Cyclops)))
+            {
+                return 0;
+            }
+
+            int depth = 500;
+            if (KnownTech.Contains(TechType.CyclopsHullModule1))
+            {
+                depth = 900;
+                if (has_mod && KnownTech.Contains(TechType.CyclopsHullModule2))
+                {
+                    depth = 1300;
+                    if (KnownTech.Contains(TechType.CyclopsHullModule3))
+                    {
+                        depth = 1700;
+                    }
+                }
+            }
+
+            return depth;
+        }
+
+        public static (string, float) GetVehicleDepth()
+        {
             float maxDepth = 0f;
             string logicVehicleName = "Vehicle";
-            
-            try
+
+            if (!KnownTech.Contains(TechType.Constructor))
             {
-                hasBay = KnownTech.Contains(TechType.Constructor);
-            }
-            catch (Exception)
-            {
-                return;
+                return (logicVehicleName, maxDepth);
             }
 
-            if (!hasBay)
-            {
-                LogicVehicleDepth = 0;
-                LogicVehicle = logicVehicleName;
-                return;
-            }
-            
             bool hasModStation = KnownTech.Contains(TechType.Workbench);
-            bool hasUpgradeConsole = KnownTech.Contains(TechType.BaseUpgradeConsole) && 
+            bool hasUpgradeConsole = KnownTech.Contains(TechType.BaseUpgradeConsole) &&
                                      KnownTech.Contains(TechType.BaseMoonpool);
-            float oldDepth = maxDepth;
-            
-            if (KnownTech.Contains(TechType.Seamoth))
+
+            int candidateDepth = getSeamothDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
             {
-                maxDepth = Math.Max(maxDepth, 200f);
-                if (hasUpgradeConsole && KnownTech.Contains(TechType.VehicleHullModule1))
-                {
-                    maxDepth = Math.Max(maxDepth, 300f);
-                    if (hasModStation && KnownTech.Contains(TechType.VehicleHullModule2))
-                    {
-                        maxDepth = Math.Max(maxDepth, 500f);
-                        if (KnownTech.Contains(TechType.VehicleHullModule3))
-                        {
-                            maxDepth = Math.Max(maxDepth, 900f);
-                        }
-                    }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Seamoth";
-                }
+                logicVehicleName = "Seamoth";
+                maxDepth = candidateDepth;
             }
-            oldDepth = maxDepth;
-            if (KnownTech.Contains(TechType.Exosuit))
+
+            candidateDepth = getPrawnDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
             {
-                maxDepth = Math.Max(maxDepth, 900f);
-                if (hasUpgradeConsole && KnownTech.Contains(TechType.ExoHullModule1))
-                {
-                    maxDepth = Math.Max(maxDepth, 1300f);
-                    if (hasModStation && KnownTech.Contains(TechType.ExoHullModule2))
-                    {
-                        maxDepth = Math.Max(maxDepth, 1700f);
-                    }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Prawn Suit";
-                }
+                logicVehicleName = "Prawn";
+                maxDepth = candidateDepth;
             }
-            oldDepth = maxDepth;
-            if (KnownTech.Contains(TechType.Cyclops))
+
+            candidateDepth = getCyclopsDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
             {
-                maxDepth = Math.Max(maxDepth, 500f);
-                if (KnownTech.Contains(TechType.CyclopsHullModule1))
+                logicVehicleName = "Cyclops";
+                maxDepth = candidateDepth;
+            }
+
+            return (logicVehicleName, maxDepth);
+        }
+
+        public static (string, float) GetAdvancedDepth()
+        {
+            float maxDepth = 0;
+            string logicVehicleName = "Vehicle";
+
+            // Since Uraninite spawns ~250, this bridges nuclear from no-items/easy to uraninite
+            if (KnownTech.Contains(TechType.FarmingTray))
+            {
+                maxDepth += 200;
+                logicVehicleName = "Advanced";
+            }
+
+            bool hasReactor = false;
+            bool hasReactorCapableRoom = KnownTech.Contains(TechType.BaseRoom) || KnownTech.Contains(TechType.BaseLargeRoom);
+
+            // Uraninite spawns at ~250m; don't assume any drops from AP
+            if (BaseDepth + maxDepth >= 250 && hasReactorCapableRoom && KnownTech.Contains(TechType.BaseNuclearReactor))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            // Bio fuel is easy to come by at all depths
+            if (hasReactorCapableRoom && KnownTech.Contains(TechType.BaseBioReactor))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            // Need the transmitter to get the electricity back to the base
+            if (KnownTech.Contains(TechType.ThermalPlant) && KnownTech.Contains(TechType.PowerTransmitter))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            if (hasReactor)
+            {
+                maxDepth += 1500;
+            }
+
+            return (logicVehicleName, maxDepth);
+        }
+
+        public static void UpdateTrackedLocation()
+        {
+            float closestDist = 100000.0f;
+            long closestID = -1;
+            long trackingCount = 0;
+            Vector3 playerPos = Player.main.gameObject.transform.position;
+
+            foreach (var locID in APState.Session.Locations.AllMissingLocations)
+            {
+                // Check that it's a static location
+                if (locID < creatureScanCutOff)
                 {
-                    maxDepth = Math.Max(maxDepth, 900f);
-                    if (hasModStation && KnownTech.Contains(TechType.CyclopsHullModule2))
+                    trackingCount++;
+                    // Skip locations not in logic
+                    if (APState.TrackedMode == TrackerMode.Logical && !InLogic(locID))
                     {
-                        maxDepth = Math.Max(maxDepth, 1300f);
-                        if (KnownTech.Contains(TechType.CyclopsHullModule3))
-                        {
-                            maxDepth = Math.Max(maxDepth, 1700f);
-                        }
+                        continue;
                     }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Cyclops";
+                    float dist = Vector3.Distance(playerPos, ArchipelagoData.Locations[locID].Position);
+                    if (dist < closestDist)
+                    {
+                        closestDist = dist;
+                        closestID = locID;
+                    }
                 }
             }
 
-            LogicVehicle = logicVehicleName;
-            LogicVehicleDepth = maxDepth;
+            APState.TrackedLocationsCount = trackingCount;
+            APState.TrackedDistance = closestDist;
+            APState.TrackedLocation = closestID;
+            if (closestID != -1)
+            {
+                APState.TrackedLocationName = APState.Session.Locations.GetLocationNameFromId(APState.TrackedLocation);
+                Vector3 directionVector = ArchipelagoData.Locations[closestID].Position - Player.main.gameObject.transform.position;
+                directionVector.Normalize();
+                APState.TrackedAngle = Vector3.Angle(directionVector, Player.main.viewModelCamera.transform.forward);
+            }
         }
-        
+
+        public static void UpdateTrackedFish()
+        {
+            long maxFish = 7;
+            var remainingFish = new List<long>();
+            foreach (var locID in APState.Session.Locations.AllMissingLocations)
+            {
+                // Check that it's a static location
+                if (locID > creatureScanCutOff)
+                {
+                    remainingFish.Add(locID);
+                }
+            }
+
+            APState.TrackedFishCount = remainingFish.Count;
+            if (APState.TrackedFishCount == 0)
+            {
+                APState.TrackedFish = "";
+                return;
+            }
+
+            remainingFish.Sort();
+            var display_fish = new List<string>();
+            for (int i = 0; i < Math.Min(APState.TrackedFishCount, maxFish); i++)
+            {
+                display_fish.Add(
+                    APState.Session.Locations.GetLocationNameFromId(
+                        remainingFish[i]).Replace(
+                        " Scan", ""));
+            }
+            APState.TrackedFish = String.Join(", ", display_fish);
+        }
+
         // Debug.Log doesn't want to work for me in the thread, despite documentation saying it is threadsafe.
         // So this is the solution for now, and probably ever.
         public static void Log(string text)
@@ -223,123 +343,60 @@ namespace Archipelago
                 sw.WriteLine(text);
             }
         }
-        
+
+        public static bool KnownTechLoaded()
+        {
+            try
+            {
+                // Doesn't matter what we check for here, we don't care about the results
+                KnownTech.Contains(TechType.Seaglide);
+            }
+            catch (NullReferenceException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public static void DoWork()
         {
-            float closestDist;
-            float dist;
-            long closestID;
-            long scanCutOff = 33999;
-            long maxFish = 7;
-
-
-            Vector3 playerPos;
-            
             while (true)
             {
+                Thread.Sleep(150);
+
+                // These three variables are close, but there's still a race condition
+                // so add a check for the KnownTech object as well
+                if (APState.state != APState.State.InGame
+                    || APState.Session == null
+                    || Player.main == null
+                    || !KnownTechLoaded())
+                {
+                    APState.TrackedFishCount = 0;
+                    APState.TrackedLocationsCount = 0;
+                    APState.TrackedLocation = -1;
+                    continue;
+                }
 
                 if (APState.SwimRule != DepthString)
                 {
                     PrimeDepthSystem();
                 }
 
-                if (ItemsRelevant)
+                LogicSwimDepth = BaseDepth + GetLogicDepth();
+
+                bool seamothCanMakeIt = TheoreticalSeamothDepth > 1443;
+                if (!seamothCanMakeIt && !IncludePrawn && !IncludeCyclops)
                 {
-                    UpdateLogicDepth();
+                    (LogicVehicle, LogicVehicleDepth) = GetAdvancedDepth();
                 }
                 else
                 {
-                    LogicSwimDepth = BaseDepth;
-                }
-                
-                UpdateVehicleDepth();
-                // locations
-                long trackingCount = 0;
-                if (APState.state == APState.State.InGame && APState.Session != null && Player.main != null)
-                {
-                    playerPos = Player.main.gameObject.transform.position;
-                    
-                    closestDist = 100000.0f;
-                    closestID = -1;
-                    foreach (var locID in APState.Session.Locations.AllMissingLocations)
-                    {
-                        // Check that it's a static location
-                        if (locID < scanCutOff)
-                        {
-                            trackingCount++;
-                            // Skip locations not in logic
-                            if (APState.TrackedMode == TrackerMode.Logical && !InLogic(locID))
-                            {
-                                continue;
-                            }
-                            dist = Vector3.Distance(playerPos, ArchipelagoData.Locations[locID].Position);
-                            if (dist < closestDist)
-                            {
-                                closestDist = dist;
-                                closestID = locID;
-                            }
-                        }
-                    }
-
-                    APState.TrackedLocationsCount = trackingCount;
-                    APState.TrackedDistance = closestDist;
-                    APState.TrackedLocation = closestID;
-                    if (closestID != -1)
-                    {
-                        APState.TrackedLocationName =
-                            APState.Session.Locations.GetLocationNameFromId(APState.TrackedLocation);
-                        Vector3 directionVector = ArchipelagoData.Locations[closestID].Position - 
-                                                  Player.main.gameObject.transform.position;
-                        directionVector.Normalize();
-                        APState.TrackedAngle = Vector3.Angle(directionVector, 
-                            Player.main.viewModelCamera.transform.forward);
-                    }
-                }
-                else
-                {
-                    APState.TrackedLocationsCount = 0;
-                    APState.TrackedLocation = -1;
-                }
-                // fish
-                if (APState.Session != null)
-                {
-
-                    var remainingFish = new List<long>();
-
-                    foreach (var locID in APState.Session.Locations.AllMissingLocations)
-                    {
-                        // Check that it's a static location
-                        if (locID > scanCutOff)
-                        {
-                            remainingFish.Add(locID);
-                        }
-                    }
-
-                    APState.TrackedFishCount = remainingFish.Count;
-                    if (APState.TrackedFishCount != 0)
-                    {
-                        remainingFish.Sort();
-                        var display_fish = new List<string>();
-                        for (int i = 0; i < Math.Min(APState.TrackedFishCount, maxFish); i++)
-                        {
-                            display_fish.Add(
-                                APState.Session.Locations.GetLocationNameFromId(
-                                    remainingFish[i]).Replace(
-                                    " Scan", ""));
-                        }
-                        APState.TrackedFish = String.Join(", ", display_fish);
-                    }
-                    else
-                    {
-                        APState.TrackedFish = "";
-                    }
-                }
-                else
-                {
-                    APState.TrackedFishCount = 0;
+                    (LogicVehicle, LogicVehicleDepth) = GetVehicleDepth();
                 }
 
-                Thread.Sleep(150);
+                UpdateTrackedLocation();
+                UpdateTrackedFish();
             }
         }
     }

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -214,16 +214,6 @@ namespace Archipelago
             LogicVehicleDepth = maxDepth;
         }
         
-        // Debug.Log doesn't want to work for me in the thread, despite documentation saying it is threadsafe.
-        // So this is the solution for now, and probably ever.
-        public static void Log(string text)
-        {
-            using (StreamWriter sw = File.AppendText("TrackerThread.txt"))
-            {
-                sw.WriteLine(text);
-            }
-        }
-        
         public static void DoWork()
         {
             float closestDist;

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using UnityEngine;
 

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -333,16 +333,6 @@ namespace Archipelago
             APState.TrackedFish = String.Join(", ", display_fish);
         }
 
-        // Debug.Log doesn't want to work for me in the thread, despite documentation saying it is threadsafe.
-        // So this is the solution for now, and probably ever.
-        public static void Log(string text)
-        {
-            using (StreamWriter sw = File.AppendText("TrackerThread.txt"))
-            {
-                sw.WriteLine(text);
-            }
-        }
-
         public static bool KnownTechLoaded()
         {
             try

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -11,30 +11,27 @@ namespace Archipelago
         Closest,
         Logical,
     }
-    
+
     public class TrackerThread
     {
         public static string DepthString = "";
         public static bool ItemsRelevant = true;
         public static float BaseDepth = 600f;
         public static float LogicSwimDepth = BaseDepth;
+        public static float TheoreticalSeamothDepth = BaseDepth;
+        public static bool IncludeSeamoth = true;
+        public static bool IncludePrawn = true;
+        public static bool IncludeCyclops = true;
         public static float LogicVehicleDepth = 0;
         public static string LogicVehicle = "Vehicle";
+        public static long creatureScanCutOff = 33999;
+
         public static bool InLogic(long locID)
         {
             // Gating items
             foreach (var logic in ArchipelagoData.LogicDict)
             {
-                bool hasItem;
-                try
-                {
-                    hasItem = KnownTech.Contains(logic.Key);
-                }
-                catch (NullReferenceException)
-                {
-                    hasItem = false;
-                }
-                
+                bool hasItem = KnownTech.Contains(logic.Key);
                 if (!hasItem && logic.Value.Contains(locID))
                 {
                     return false;
@@ -46,289 +43,359 @@ namespace Archipelago
 
         public static void PrimeDepthSystem()
         {
+            DepthString    = APState.SwimRule;
+            BaseDepth      = APState.SwimDepth;
+            ItemsRelevant  = APState.ItemsRelevant;
+            IncludeSeamoth = APState.SeamothState == APState.Inclusion.Included;
+            IncludePrawn   = APState.PrawnState == APState.Inclusion.Included;
+            IncludeCyclops = APState.CyclopsState == APState.Inclusion.Included;
 
-            DepthString = APState.SwimRule;
-            if (DepthString.Length == 0)
+            TheoreticalSeamothDepth = BaseDepth;
+            if (IncludeSeamoth)
             {
-                // assume most permissive logic if none given
-                DepthString = "items_hard";
-            }
-
-            var nameParts = DepthString.Split('_');
-
-            ItemsRelevant = nameParts.Length > 1;
-            switch (nameParts.GetLast())
-            {
-                case "easy":
-                {
-                    BaseDepth = 200f;
-                    break;
-                }
-                case "normal":
-                {
-                    BaseDepth = 400f;
-                    break;
-                }
-                case "hard":
-                {
-                    BaseDepth = 600f;
-                    break;
-                }
+                TheoreticalSeamothDepth = getTheoreticalLogicDepth(900f);
             }
         }
 
-        public static void UpdateLogicDepth()
+        public static float getTheoreticalLogicDepth(float candidateVehicleDepth)
         {
-            float swimdepth = BaseDepth;
-            bool hasModStation;
-            try
+            float coreDepth = BaseDepth + candidateVehicleDepth;
+            if (ItemsRelevant)
             {
-                hasModStation = KnownTech.Contains(TechType.Workbench);
+                return coreDepth + 350f;
             }
-            catch (NullReferenceException)
+
+            return coreDepth;
+        }
+
+        public static float GetLogicDepth()
+        {
+            float itemdepth = 0;
+
+            if (! ItemsRelevant)
             {
-                return;
+                return itemdepth;
             }
+
+            bool hasModStation = KnownTech.Contains(TechType.Workbench);
 
             if (KnownTech.Contains(TechType.Seaglide))
             {
-                swimdepth += 200f;
+                itemdepth += 200f;
                 // Ultra High Capacity Tank
                 if (hasModStation && KnownTech.Contains(TechType.HighCapacityTank))
                 {
-                    swimdepth += 150f;
+                    itemdepth += 150f;
                 }
             }
             else if (hasModStation && KnownTech.Contains(TechType.UltraGlideFins))
             {
-                swimdepth += 50f;
+                itemdepth += 50f;
                 if (KnownTech.Contains(TechType.HighCapacityTank))
                 {
-                    swimdepth += 100f;
+                    itemdepth += 100f;
                 }
                 else if (KnownTech.Contains(TechType.PlasteelTank))
                 {
-                    swimdepth += 25f;
+                    itemdepth += 25f;
                 }
             }
             else if (hasModStation && KnownTech.Contains(TechType.HighCapacityTank))
             {
-                swimdepth += 100f;
+                itemdepth += 100f;
             }
             else if (hasModStation && KnownTech.Contains(TechType.PlasteelTank))
             {
-                swimdepth += 25f;
+                itemdepth += 25f;
             }
 
-            LogicSwimDepth = swimdepth;
+            return itemdepth;
         }
 
-        public static void UpdateVehicleDepth()
+        public static int getSeamothDepth(bool has_mod, bool has_upg)
         {
-            bool hasBay;
+            if (! (IncludeSeamoth && KnownTech.Contains(TechType.Seamoth)))
+            {
+                return 0;
+            }
+
+            int depth = 200;
+            if (has_upg && KnownTech.Contains(TechType.VehicleHullModule1))
+            {
+                depth = 300;
+                if (has_mod && KnownTech.Contains(TechType.VehicleHullModule2))
+                {
+                    depth = 500;
+                    if (KnownTech.Contains(TechType.VehicleHullModule3))
+                    {
+                        depth = 900;
+                    }
+                }
+            }
+
+            return depth;
+        }
+
+        public static int getPrawnDepth(bool has_mod, bool has_upg)
+        {
+            if (! (IncludePrawn && KnownTech.Contains(TechType.Exosuit)))
+            {
+                return 0;
+            }
+
+            int depth = 900;
+            if (has_upg && KnownTech.Contains(TechType.ExoHullModule1))
+            {
+                depth = 1300;
+                if (has_mod && KnownTech.Contains(TechType.ExoHullModule2))
+                {
+                    depth = 1700;
+                }
+            }
+
+            return depth;
+        }
+
+        public static int getCyclopsDepth(bool has_mod, bool has_upg)
+        {
+            if (! (IncludeCyclops && KnownTech.Contains(TechType.Cyclops)))
+            {
+                return 0;
+            }
+
+            int depth = 500;
+            if (KnownTech.Contains(TechType.CyclopsHullModule1))
+            {
+                depth = 900;
+                if (has_mod && KnownTech.Contains(TechType.CyclopsHullModule2))
+                {
+                    depth = 1300;
+                    if (KnownTech.Contains(TechType.CyclopsHullModule3))
+                    {
+                        depth = 1700;
+                    }
+                }
+            }
+
+            return depth;
+        }
+
+        public static (string, float) GetVehicleDepth()
+        {
             float maxDepth = 0f;
             string logicVehicleName = "Vehicle";
-            
+
+            if (!KnownTech.Contains(TechType.Constructor))
+            {
+                return (logicVehicleName, maxDepth);
+            }
+
+            bool hasModStation = KnownTech.Contains(TechType.Workbench);
+            bool hasUpgradeConsole = KnownTech.Contains(TechType.BaseUpgradeConsole) &&
+                                     KnownTech.Contains(TechType.BaseMoonpool);
+
+            int candidateDepth = getSeamothDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
+            {
+                logicVehicleName = "Seamoth";
+                maxDepth = candidateDepth;
+            }
+
+            candidateDepth = getPrawnDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
+            {
+                logicVehicleName = "Prawn";
+                maxDepth = candidateDepth;
+            }
+
+            candidateDepth = getCyclopsDepth(hasModStation, hasUpgradeConsole);
+            if (candidateDepth > maxDepth)
+            {
+                logicVehicleName = "Cyclops";
+                maxDepth = candidateDepth;
+            }
+
+            return (logicVehicleName, maxDepth);
+        }
+
+        public static (string, float) GetAdvancedDepth()
+        {
+            float maxDepth = 0;
+            string logicVehicleName = "Vehicle";
+
+            // Since Uraninite spawns ~250, this bridges nuclear from no-items/easy to uraninite
+            if (KnownTech.Contains(TechType.FarmingTray))
+            {
+                maxDepth += 200;
+                logicVehicleName = "Advanced";
+            }
+
+            bool hasReactor = false;
+            bool hasReactorCapableRoom = KnownTech.Contains(TechType.BaseRoom) || KnownTech.Contains(TechType.BaseLargeRoom);
+
+            // Uraninite spawns at ~250m; don't assume any drops from AP
+            if (BaseDepth + maxDepth >= 250 && hasReactorCapableRoom && KnownTech.Contains(TechType.BaseNuclearReactor))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            // Bio fuel is easy to come by at all depths
+            if (hasReactorCapableRoom && KnownTech.Contains(TechType.BaseBioReactor))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            // Need the transmitter to get the electricity back to the base
+            if (KnownTech.Contains(TechType.ThermalPlant) && KnownTech.Contains(TechType.PowerTransmitter))
+            {
+                hasReactor = true;
+                logicVehicleName = "Advanced";
+            }
+
+            if (hasReactor)
+            {
+                maxDepth += 1500;
+            }
+
+            return (logicVehicleName, maxDepth);
+        }
+
+        public static void UpdateTrackedLocation()
+        {
+            float closestDist = 100000.0f;
+            long closestID = -1;
+            long trackingCount = 0;
+            Vector3 playerPos = Player.main.gameObject.transform.position;
+
+            foreach (var locID in APState.Session.Locations.AllMissingLocations)
+            {
+                // Check that it's a static location
+                if (locID < creatureScanCutOff)
+                {
+                    trackingCount++;
+                    // Skip locations not in logic
+                    if (APState.TrackedMode == TrackerMode.Logical && !InLogic(locID))
+                    {
+                        continue;
+                    }
+                    float dist = Vector3.Distance(playerPos, ArchipelagoData.Locations[locID].Position);
+                    if (dist < closestDist)
+                    {
+                        closestDist = dist;
+                        closestID = locID;
+                    }
+                }
+            }
+
+            APState.TrackedLocationsCount = trackingCount;
+            APState.TrackedDistance = closestDist;
+            APState.TrackedLocation = closestID;
+            if (closestID != -1)
+            {
+                APState.TrackedLocationName = APState.Session.Locations.GetLocationNameFromId(APState.TrackedLocation);
+                Vector3 directionVector = ArchipelagoData.Locations[closestID].Position - Player.main.gameObject.transform.position;
+                directionVector.Normalize();
+                APState.TrackedAngle = Vector3.Angle(directionVector, Player.main.viewModelCamera.transform.forward);
+            }
+        }
+
+        public static void UpdateTrackedFish()
+        {
+            long maxFish = 7;
+            var remainingFish = new List<long>();
+            foreach (var locID in APState.Session.Locations.AllMissingLocations)
+            {
+                // Check that it's a static location
+                if (locID > creatureScanCutOff)
+                {
+                    remainingFish.Add(locID);
+                }
+            }
+
+            APState.TrackedFishCount = remainingFish.Count;
+            if (APState.TrackedFishCount == 0)
+            {
+                APState.TrackedFish = "";
+                return;
+            }
+
+            remainingFish.Sort();
+            var display_fish = new List<string>();
+            for (int i = 0; i < Math.Min(APState.TrackedFishCount, maxFish); i++)
+            {
+                display_fish.Add(
+                    APState.Session.Locations.GetLocationNameFromId(
+                        remainingFish[i]).Replace(
+                        " Scan", ""));
+            }
+            APState.TrackedFish = String.Join(", ", display_fish);
+        }
+
+        // Debug.Log doesn't want to work for me in the thread, despite documentation saying it is threadsafe.
+        // So this is the solution for now, and probably ever.
+        public static void Log(string text)
+        {
+            using (StreamWriter sw = File.AppendText("TrackerThread.txt"))
+            {
+                sw.WriteLine(text);
+            }
+        }
+
+        public static bool KnownTechLoaded()
+        {
             try
             {
-                hasBay = KnownTech.Contains(TechType.Constructor);
+                // Doesn't matter what we check for here, we don't care about the results
+                KnownTech.Contains(TechType.Seaglide);
             }
-            catch (Exception)
+            catch (NullReferenceException)
             {
-                return;
+                return false;
             }
 
-            if (!hasBay)
-            {
-                LogicVehicleDepth = 0;
-                LogicVehicle = logicVehicleName;
-                return;
-            }
-            
-            bool hasModStation = KnownTech.Contains(TechType.Workbench);
-            bool hasUpgradeConsole = KnownTech.Contains(TechType.BaseUpgradeConsole) && 
-                                     KnownTech.Contains(TechType.BaseMoonpool);
-            float oldDepth = maxDepth;
-            
-            if (KnownTech.Contains(TechType.Seamoth))
-            {
-                maxDepth = Math.Max(maxDepth, 200f);
-                if (hasUpgradeConsole && KnownTech.Contains(TechType.VehicleHullModule1))
-                {
-                    maxDepth = Math.Max(maxDepth, 300f);
-                    if (hasModStation && KnownTech.Contains(TechType.VehicleHullModule2))
-                    {
-                        maxDepth = Math.Max(maxDepth, 500f);
-                        if (KnownTech.Contains(TechType.VehicleHullModule3))
-                        {
-                            maxDepth = Math.Max(maxDepth, 900f);
-                        }
-                    }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Seamoth";
-                }
-            }
-            oldDepth = maxDepth;
-            if (KnownTech.Contains(TechType.Exosuit))
-            {
-                maxDepth = Math.Max(maxDepth, 900f);
-                if (hasUpgradeConsole && KnownTech.Contains(TechType.ExoHullModule1))
-                {
-                    maxDepth = Math.Max(maxDepth, 1300f);
-                    if (hasModStation && KnownTech.Contains(TechType.ExoHullModule2))
-                    {
-                        maxDepth = Math.Max(maxDepth, 1700f);
-                    }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Prawn Suit";
-                }
-            }
-            oldDepth = maxDepth;
-            if (KnownTech.Contains(TechType.Cyclops))
-            {
-                maxDepth = Math.Max(maxDepth, 500f);
-                if (KnownTech.Contains(TechType.CyclopsHullModule1))
-                {
-                    maxDepth = Math.Max(maxDepth, 900f);
-                    if (hasModStation && KnownTech.Contains(TechType.CyclopsHullModule2))
-                    {
-                        maxDepth = Math.Max(maxDepth, 1300f);
-                        if (KnownTech.Contains(TechType.CyclopsHullModule3))
-                        {
-                            maxDepth = Math.Max(maxDepth, 1700f);
-                        }
-                    }
-                }
-                if (Math.Abs(oldDepth - maxDepth) > 1)
-                {
-                    logicVehicleName = "Cyclops";
-                }
-            }
-
-            LogicVehicle = logicVehicleName;
-            LogicVehicleDepth = maxDepth;
+            return true;
         }
-        
+
         public static void DoWork()
         {
-            float closestDist;
-            float dist;
-            long closestID;
-            long scanCutOff = 33999;
-            long maxFish = 7;
-
-
-            Vector3 playerPos;
-            
             while (true)
             {
+                Thread.Sleep(150);
+
+                // These three variables are close, but there's still a race condition
+                // so add a check for the KnownTech object as well
+                if (APState.state != APState.State.InGame
+                    || APState.Session == null
+                    || Player.main == null
+                    || !KnownTechLoaded())
+                {
+                    APState.TrackedFishCount = 0;
+                    APState.TrackedLocationsCount = 0;
+                    APState.TrackedLocation = -1;
+                    continue;
+                }
 
                 if (APState.SwimRule != DepthString)
                 {
                     PrimeDepthSystem();
                 }
 
-                if (ItemsRelevant)
+                LogicSwimDepth = BaseDepth + GetLogicDepth();
+
+                bool seamothCanMakeIt = TheoreticalSeamothDepth > 1443;
+                if (!seamothCanMakeIt && !IncludePrawn && !IncludeCyclops)
                 {
-                    UpdateLogicDepth();
+                    (LogicVehicle, LogicVehicleDepth) = GetAdvancedDepth();
                 }
                 else
                 {
-                    LogicSwimDepth = BaseDepth;
-                }
-                
-                UpdateVehicleDepth();
-                // locations
-                long trackingCount = 0;
-                if (APState.state == APState.State.InGame && APState.Session != null && Player.main != null)
-                {
-                    playerPos = Player.main.gameObject.transform.position;
-                    
-                    closestDist = 100000.0f;
-                    closestID = -1;
-                    foreach (var locID in APState.Session.Locations.AllMissingLocations)
-                    {
-                        // Check that it's a static location
-                        if (locID < scanCutOff)
-                        {
-                            trackingCount++;
-                            // Skip locations not in logic
-                            if (APState.TrackedMode == TrackerMode.Logical && !InLogic(locID))
-                            {
-                                continue;
-                            }
-                            dist = Vector3.Distance(playerPos, ArchipelagoData.Locations[locID].Position);
-                            if (dist < closestDist)
-                            {
-                                closestDist = dist;
-                                closestID = locID;
-                            }
-                        }
-                    }
-
-                    APState.TrackedLocationsCount = trackingCount;
-                    APState.TrackedDistance = closestDist;
-                    APState.TrackedLocation = closestID;
-                    if (closestID != -1)
-                    {
-                        APState.TrackedLocationName =
-                            APState.Session.Locations.GetLocationNameFromId(APState.TrackedLocation);
-                        Vector3 directionVector = ArchipelagoData.Locations[closestID].Position - 
-                                                  Player.main.gameObject.transform.position;
-                        directionVector.Normalize();
-                        APState.TrackedAngle = Vector3.Angle(directionVector, 
-                            Player.main.viewModelCamera.transform.forward);
-                    }
-                }
-                else
-                {
-                    APState.TrackedLocationsCount = 0;
-                    APState.TrackedLocation = -1;
-                }
-                // fish
-                if (APState.Session != null)
-                {
-
-                    var remainingFish = new List<long>();
-
-                    foreach (var locID in APState.Session.Locations.AllMissingLocations)
-                    {
-                        // Check that it's a static location
-                        if (locID > scanCutOff)
-                        {
-                            remainingFish.Add(locID);
-                        }
-                    }
-
-                    APState.TrackedFishCount = remainingFish.Count;
-                    if (APState.TrackedFishCount != 0)
-                    {
-                        remainingFish.Sort();
-                        var display_fish = new List<string>();
-                        for (int i = 0; i < Math.Min(APState.TrackedFishCount, maxFish); i++)
-                        {
-                            display_fish.Add(
-                                APState.Session.Locations.GetLocationNameFromId(
-                                    remainingFish[i]).Replace(
-                                    " Scan", ""));
-                        }
-                        APState.TrackedFish = String.Join(", ", display_fish);
-                    }
-                    else
-                    {
-                        APState.TrackedFish = "";
-                    }
-                }
-                else
-                {
-                    APState.TrackedFishCount = 0;
+                    (LogicVehicle, LogicVehicleDepth) = GetVehicleDepth();
                 }
 
-                Thread.Sleep(150);
+                UpdateTrackedLocation();
+                UpdateTrackedFish();
             }
         }
     }


### PR DESCRIPTION
Defaults to vehicles being in game which allows backwards compatibility with older AP versions that won't send/understand the new options.

If the Cyclops is out of the game, the Shield Generator is put onto the Vehicle Upgrade Console (screenshots below).
If all three vehicles are out of the game, "advanced" logic takes over which checks for reactors in order to make chains of bases. It's currently aided by Exterior Growbed just to add enough depth to get to uraninite for the nuclear reactor (which can spawn below "easy" with no items depth). Tweaks to the advanced algorithm are expected.

There's a massive overhaul of the Tracker in here, which will hopefully make future changes easier as well.

Screenshots of the Cyclops Shield Generator (related to Cyclops being unavailable):
<img width="691" alt="Screenshot 2024-05-05 at 21 19 34" src="https://github.com/Berserker66/ArchipelagoSubnauticaModSrc/assets/4594575/be99fade-4222-4bce-9a69-068e922d1501">

<img width="1162" alt="Screenshot 2024-05-05 at 21 19 57" src="https://github.com/Berserker66/ArchipelagoSubnauticaModSrc/assets/4594575/f654eec7-ab39-4178-99e0-462e16dbba0c">
