### PR TITLE
Minor tracker updates

### DIFF
--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -29,7 +29,8 @@ namespace Archipelago
         public enum State
         {
             Menu,
-            InGame
+            InGame,
+            Cancelled
         }
 
         public static Dictionary<string, string> GoalMapping = new Dictionary<string, string>()
@@ -62,6 +63,7 @@ namespace Archipelago
         public static string TrackedLocationName;
         public static float TrackedDistance;
         public static float TrackedAngle;
+        public static int TrackedDepth;
         public static ManualLogSource Logger;
 
         public static ArchipelagoSession Session;
@@ -146,6 +148,7 @@ namespace Archipelago
             TechType.SingleWallShelf,
             TechType.WallShelves,
             TechType.Bench,
+            TechType.PictureFrame,
             TechType.PlanterPot,
             TechType.PlanterShelf,
             TechType.PlanterPot2,
@@ -270,8 +273,8 @@ namespace Archipelago
             TechFragmentsToDestroy = new HashSet<TechType>(APState.tech_fragments);
             // remove vanilla so it's scannable
             TechFragmentsToDestroy.ExceptWith(vanillaTech);
-            Debug.LogError("Preventing scanning of: " + string.Join(", ", TechFragmentsToDestroy));
-            Debug.LogError("Allowing scanning of: " + string.Join(", ", vanillaTech));
+            Debug.Log("Preventing scanning of: " + string.Join(", ", TechFragmentsToDestroy));
+            Debug.Log("Allowing scanning of: " + string.Join(", ", vanillaTech));
             return loginResult.Successful;
         }
         

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -942,7 +942,6 @@ namespace Archipelago
             switch (__instance.techType)
             {
                 case TechType.RadiationSuit:
-                case TechType.PrecursorIonPowerCell:
                 case TechType.BaseLargeRoom:
                 case TechType.PrecursorIonBattery:
                 case TechType.PrecursorIonPowerCell:

--- a/mod/ArchipelagoData.cs
+++ b/mod/ArchipelagoData.cs
@@ -95,7 +95,7 @@ public static class ArchipelagoData
             }
         }
 
-        Debug.LogError("ItemCodeToItemType " + JsonConvert.SerializeObject(ItemCodeToItemType));
+        Debug.Log("ItemCodeToItemType " + JsonConvert.SerializeObject(ItemCodeToItemType));
         Initialized = true;
     }
 }

--- a/mod/Tracker.cs
+++ b/mod/Tracker.cs
@@ -286,6 +286,8 @@ namespace Archipelago
                     APState.TrackedLocation = closestID;
                     if (closestID != -1)
                     {
+                        APState.TrackedDepth =
+                            Convert.ToInt32(ArchipelagoData.Locations[closestID].Position.y);
                         APState.TrackedLocationName =
                             APState.Session.Locations.GetLocationNameFromId(APState.TrackedLocation);
                         Vector3 directionVector = ArchipelagoData.Locations[closestID].Position - 


### PR DESCRIPTION

This is functionally a menu. Anything you're not interested let me know and it'll get cut. These are all pretty small so I bundled them.

Based on recent work regarding changing directories i'm not expecting the first one to make the cut, but it seems to work, so here it is.

Some of the items are up to preferences. Feel free to ask for any amount of rework.

I think I accidentally put the fish bit into two separate PRs; I can cut it from either (or both) depending on interest (sorry about the duplication).

Here's what's available:
    - Add "Cancel" button which allows playing original Subnautica with AP plugin installed
    - Add depth of tracked target to tracker display
    - Display number of locations still pending even when none are in logic.
    - Disable Picture Frame from being scanned
    - Change various "LogError" messages to "Log" messages (don't scare players)
    - Shrink size of field inputs slightly
    - Move up target tracker when fish are not being tracked (remove blank space, save screen real estate)