### PR TITLE
Added PropulsionCannonLogic compatibility

### DIFF
--- a/mod/APSpawnHandler.cs
+++ b/mod/APSpawnHandler.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using HarmonyLib;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using Archipelago.MultiClient.Net.Packets;
+using System.Text;
+using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
+using Newtonsoft.Json;
+using Debug = UnityEngine.Debug;
+using File = System.IO.File;
+using Object = UnityEngine.Object;
+
+namespace Archipelago
+{
+    //This class handles features that involve spawning in objects to alter progression.
+    public class APSpawnHandler : MonoBehaviour
+    {
+        public List<GameObject> AuroraBlockers = new List<GameObject>();
+        public bool SpawnsComplete = false;
+
+        //Add a handler to the Player object if not present, then spawn necessary items
+        //Will only do so if a Player object has been instantiated and a valid AP connection is present
+        public static void AddHandlerAndSpawnBarriers()
+        {
+            Player IdentifiedPlayer = (Player)UnityEngine.Object.FindObjectOfType(typeof(Player));
+            if ((IdentifiedPlayer != null) && (APState.Session != null))
+            {
+                if (!IdentifiedPlayer.gameObject.TryGetComponent<APSpawnHandler>(out APSpawnHandler SpawnMaker))
+                {
+                    SpawnMaker = IdentifiedPlayer.gameObject.AddComponent<APSpawnHandler>();
+                }
+                SpawnMaker.AttemptSpawns();
+            }
+        }
+
+        //Attempt to spawn blockades, but only do so if it has not already been done
+        public void AttemptSpawns()
+        {
+            if (!SpawnsComplete) {
+                if (APState.PropulsionCannonLogic == "strictrequirement")
+                {
+                    APSpawnHandler.SpawnAuroraBlockers(this.AuroraBlockers);
+                }
+                SpawnsComplete = true;
+            }
+        }
+
+        //This function spawns a barricade on the upper Aurora entrance.
+        //Does not spawn if the associated list has already been added to.
+        public static void SpawnAuroraBlockers(List<GameObject> AuroraBlockers)
+        {
+            Vector3 blockRotation = new Vector3(0.0f, 232.0f, 0.0f);
+            Vector3 blockA1SpawnPoint = new Vector3(997.75f, 36.70f, 109.0f);
+            Vector3 blockB1SpawnPoint = new Vector3(998.4f, 36.7f, 108.0f);
+            Vector3 blockA2SpawnPoint = new Vector3(997.75f, 37.80f, 109.0f);
+            Vector3 blockB2SpawnPoint = new Vector3(998.4f, 37.8f, 108.0f);
+            Vector3 blockA3SpawnPoint = new Vector3(997.75f, 38.90f, 109.0f);
+            Vector3 blockB3SpawnPoint = new Vector3(998.4f, 38.9f, 108.0f);
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockA1SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockB1SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockA2SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockB2SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockA3SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+            UWE.CoroutineHost.StartCoroutine(ListNewGameObject(blockB3SpawnPoint, blockRotation,
+                TechType.StarshipCargoCrate, AuroraBlockers));
+        }
+
+        //This function generates a new game object, assigns it a position and rotation, and adds them to designated list.
+        //Currently, it can only spawn items with valid TechTypes.
+       public static IEnumerator ListNewGameObject(Vector3 spawnPosition, Vector3 eulerRotation, TechType objectTechType,
+            List<GameObject> objectList)
+        {
+            CoroutineTask<GameObject> task = CraftData.GetPrefabForTechTypeAsync(objectTechType);
+            yield return task;
+            GameObject gameObjectPrefab = task.GetResult();
+            GameObject gameObject = GameObject.Instantiate(gameObjectPrefab);
+            gameObject.transform.position = spawnPosition;
+            Quaternion spawnRotation = new Quaternion();
+            spawnRotation.eulerAngles = eulerRotation;
+            gameObject.transform.rotation = spawnRotation;
+            objectList.Add(gameObject);
+        }
+    }
+
+}

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -266,7 +266,10 @@ namespace Archipelago
                 //Check if player has a Spawn Handler component yet; if not, attach one
                 //Then attempt to spawn obstacles
                 //Note: this only fires if player connects while already in-world.
-                APSpawnHandler.AddHandlerAndSpawnBarriers();
+                APSpawnHandler.CheckConditionsForSpawn();
+
+                //Depending on player settings, update location logic
+                ArchipelagoData.UpdateLogicData();
 
             }
             else if (loginResult is LoginFailure loginFailure)

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -52,6 +52,7 @@ namespace Archipelago
         public static string Goal = "launch";
         public static string GoalEvent = "";
         public static string SwimRule = "";
+        public static string PropulsionCannonLogic = "";
         public static bool FreeSamples;
         public static bool Silent = false;
         public static Thread TrackerProcessing;
@@ -239,6 +240,10 @@ namespace Archipelago
                 {
                     SwimRule = (string)swim_rule;
                 }
+                if (loginSuccess.SlotData.TryGetValue("propulsion_cannon_logic", out var propulsion_cannon_logic))
+                {
+                    PropulsionCannonLogic = (string)propulsion_cannon_logic;
+                }
                 if (loginSuccess.SlotData.TryGetValue("free_samples", out var free_samples))
                 {
                     FreeSamples = Convert.ToInt32(free_samples) > 0;
@@ -257,6 +262,11 @@ namespace Archipelago
                 Logging.Log("SlotData: " + JsonConvert.SerializeObject(loginSuccess.SlotData), ingame:false);
                 ServerConnectInfo.death_link = Convert.ToInt32(loginSuccess.SlotData["death_link"]) > 0;
                 set_deathlink();
+
+                //Check if player has a Spawn Handler component yet; if not, attach one
+                //Then attempt to spawn obstacles
+                //Note: this only fires if player connects while already in-world.
+                APSpawnHandler.AddHandlerAndSpawnBarriers();
 
             }
             else if (loginResult is LoginFailure loginFailure)
@@ -333,7 +343,7 @@ namespace Archipelago
                 SendLocID(closest_id);
                 return true;
             }
-#if DEBUG
+/*#if DEBUG
             ErrorMessage.AddError("Tried to check unregistered Location at: " + position);
             Debug.LogError("Tried to check unregistered Location at: " + position);
             foreach (var location in LOCATIONS)
@@ -347,7 +357,7 @@ namespace Archipelago
             }
             ErrorMessage.AddError("Could it be Location ID " + closest_id + " with a distance of "+closestDist + "?");
             Debug.LogError("Could it be Location ID " + closest_id + " with a distance of "+closestDist + "?");
-#endif
+#endif*/
             return false;
         }
 

--- a/mod/APState.cs
+++ b/mod/APState.cs
@@ -263,13 +263,17 @@ namespace Archipelago
                 ServerConnectInfo.death_link = Convert.ToInt32(loginSuccess.SlotData["death_link"]) > 0;
                 set_deathlink();
 
-                //Check if player has a Spawn Handler component yet; if not, attach one
-                //Then attempt to spawn obstacles
-                //Note: this only fires if player connects while already in-world.
-                APSpawnHandler.CheckConditionsForSpawn();
+                //For safety, don't implement the new object spawning/location changes in Below Zero
+                if (!ArchipelagoPlugin.Zero)
+                {
+                    //Check if player has a Spawn Handler component yet; if not, attach one
+                    //Then attempt to spawn obstacles
+                    //Note: this only fires if player connects while already in-world.
+                    APSpawnHandler.CheckConditionsForSpawn();
 
-                //Depending on player settings, update location logic
-                ArchipelagoData.UpdateLogicData();
+                    //Depending on player settings, update location logic
+                    ArchipelagoData.UpdateLogicData();
+                }
 
             }
             else if (loginResult is LoginFailure loginFailure)
@@ -346,7 +350,7 @@ namespace Archipelago
                 SendLocID(closest_id);
                 return true;
             }
-/*#if DEBUG
+#if DEBUG
             ErrorMessage.AddError("Tried to check unregistered Location at: " + position);
             Debug.LogError("Tried to check unregistered Location at: " + position);
             foreach (var location in LOCATIONS)
@@ -360,7 +364,7 @@ namespace Archipelago
             }
             ErrorMessage.AddError("Could it be Location ID " + closest_id + " with a distance of "+closestDist + "?");
             Debug.LogError("Could it be Location ID " + closest_id + " with a distance of "+closestDist + "?");
-#endif*/
+#endif
             return false;
         }
 

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -158,13 +158,13 @@ namespace Archipelago
                             " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth +
                             " (" + TrackerThread.LogicVehicle + ")");
                     }
-                    //Below Zero doesn't have a propulsion cannon
+                    //Below Zero doesn't have a propulsion cannon 
                     if (!ArchipelagoPlugin.Zero)
                     {
                         if (APState.PropulsionCannonLogic.Length == 0)
                         {
-                            GUI.Label(new Rect(16, 96, 1000, 22),
-                                "No Propulsion Cannon Logic sent by Server. Assuming logicrequirement.");
+                            GUI.Label(new Rect(16, 116, 1000, 22),
+                                "No Propulsion Cannon Logic sent by Server. Assuming logic_requirement.");
                         }
                         else
                         {

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -19,7 +19,7 @@ namespace Archipelago
 {
     public class ArchipelagoUI : MonoBehaviour
     {
-        /*#if DEBUG
+        #if DEBUG
                 public static string mouse_target_desc = "";
                 private bool show_warps = false;
                 private bool show_items = false;
@@ -65,14 +65,14 @@ namespace Archipelago
                     }
                     copied_fade -= Time.deltaTime;
                 }
-        #endif*/
+        #endif
 
         void OnGUI()
         {
             Logging.TryUpdateLog();
-/*#if DEBUG
+#if DEBUG
             GUI.Box(new Rect(0, 0, Screen.width, 140), "");
-#endif*/
+#endif
             string ap_ver = "Archipelago v" + APState.AP_VERSION[0] + "." + APState.AP_VERSION[1] + "." + APState.AP_VERSION[2];
             if (APState.Session != null)
             {
@@ -158,17 +158,20 @@ namespace Archipelago
                             " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth +
                             " (" + TrackerThread.LogicVehicle + ")");
                     }
-                    if (APState.PropulsionCannonLogic.Length == 0)
+                    //Below Zero doesn't have a propulsion cannon
+                    if (!ArchipelagoPlugin.Zero)
                     {
-                        GUI.Label(new Rect(16, 96, 1000, 22),
-                            "No Propulsion Cannon Logic sent by Server. Assuming logicrequirement.");
+                        if (APState.PropulsionCannonLogic.Length == 0)
+                        {
+                            GUI.Label(new Rect(16, 96, 1000, 22),
+                                "No Propulsion Cannon Logic sent by Server. Assuming logicrequirement.");
+                        }
+                        else
+                        {
+                            GUI.Label(new Rect(16, 116, 1000, 22),
+                            "Propulsion Cannon Logic: " + APState.PropulsionCannonLogic);
+                        }
                     }
-                    else
-                    {
-                        GUI.Label(new Rect(16, 116, 1000, 22),
-                        "Propulsion Cannon Logic: " + APState.PropulsionCannonLogic);
-                    }
-                    
                 }
                 if (!APState.TrackerProcessing.IsAlive)
                 {
@@ -177,7 +180,7 @@ namespace Archipelago
                 }
             }
 
-            /*#if DEBUG
+            #if DEBUG
                         GUI.Label(new Rect(16, 16 + 20, Screen.width - 32, 50), ((copied_fade > 0.0f) ? "Copied!" : "Target: ") + mouse_target_desc);
 
                         if (APState.state != APState.State.Menu)
@@ -243,7 +246,7 @@ namespace Archipelago
                                 }
                             }
                         }
-            #endif*/
+            #endif
         }
 
         public bool PlayerNearStart()
@@ -828,7 +831,7 @@ namespace Archipelago
         }
     }
 
-    /*#if DEBUG
+    #if DEBUG
         [HarmonyPatch(typeof(GUIHand))]
         [HarmonyPatch("OnUpdate")]
         internal class GUIHand_OnUpdate_Patch
@@ -845,7 +848,7 @@ namespace Archipelago
                     ArchipelagoUI.mouse_target_desc = "";
             }
         }
-    #endif*/
+    #endif
 
     //[HarmonyPatch(typeof(LeakingRadiation))]
     //[HarmonyPatch("Start")]

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -19,60 +19,60 @@ namespace Archipelago
 {
     public class ArchipelagoUI : MonoBehaviour
     {
-#if DEBUG
-        public static string mouse_target_desc = "";
-        private bool show_warps = false;
-        private bool show_items = false;
-        private float copied_fade = 0.0f;
+        /*#if DEBUG
+                public static string mouse_target_desc = "";
+                private bool show_warps = false;
+                private bool show_items = false;
+                private float copied_fade = 0.0f;
 
-        public static Dictionary<string, Vector3> WRECKS = new Dictionary<string, Vector3>
-        {
-            { "Blood Kelp Trench 1", new Vector3(-1201, -324, -396) },
-            { "Bulb Zone 1", new Vector3(929, -198, 593) },
-            { "Bulb Zone 2", new Vector3(1309, -215, 570) },
-            { "Dunes 1", new Vector3(-1448, -332, 723) },
-            { "Dunes 2", new Vector3(-1632, -334, 83) },
-            { "Dunes 3", new Vector3(-1210, -217, 7) },
-            { "Grand Reef 1", new Vector3(-290, -222, -773) },
-            { "Grand Reef 2", new Vector3(-865, -430, -1390) },
-            { "Grassy Plateaus 1", new Vector3(-15, -96, -624) },
-            { "Grassy Plateaus 2", new Vector3(-390, -120, 648) },
-            { "Grassy Plateaus 3", new Vector3(286, -72, 444) },
-            { "Grassy Plateaus 4", new Vector3(-635, -50, -2) },
-            { "Grassy Plateaus 5", new Vector3(-432, -90, -268) },
-            { "Kelp Forest 1", new Vector3(-320, -57, 252) },
-            { "Kelp Forest 2", new Vector3(65, -25, 385) },
-            { "Mountains 1", new Vector3(701, -346, 1224) },
-            { "Mountains 2", new Vector3(1057, -254, 1359) },
-            { "Northwestern Mushroom Forest", new Vector3(-645, -120, 773) },
-            { "Safe Shallows 1", new Vector3(-40, -14, -400) },
-            { "Safe Shallows 2", new Vector3(366, -6, -203) },
-            { "Sea Treader's Path", new Vector3(-1131, -166, -729) },
-            { "Sparse Reef", new Vector3(-787, -208, -713) },
-            { "Underwater Islands", new Vector3(-102, -179, 860) }
-        };
-        void Update()
-        {
-            if (mouse_target_desc != "")
-            {
-                if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C))
+                public static Dictionary<string, Vector3> WRECKS = new Dictionary<string, Vector3>
                 {
-                    Logging.Log("INSPECT GAME OBJECT: " + mouse_target_desc, ingame:false);
-                    string id = mouse_target_desc.Split(new char[] { ':' })[0];
-                    GUIUtility.systemCopyBuffer = id;
-                    copied_fade = 1.0f;
+                    { "Blood Kelp Trench 1", new Vector3(-1201, -324, -396) },
+                    { "Bulb Zone 1", new Vector3(929, -198, 593) },
+                    { "Bulb Zone 2", new Vector3(1309, -215, 570) },
+                    { "Dunes 1", new Vector3(-1448, -332, 723) },
+                    { "Dunes 2", new Vector3(-1632, -334, 83) },
+                    { "Dunes 3", new Vector3(-1210, -217, 7) },
+                    { "Grand Reef 1", new Vector3(-290, -222, -773) },
+                    { "Grand Reef 2", new Vector3(-865, -430, -1390) },
+                    { "Grassy Plateaus 1", new Vector3(-15, -96, -624) },
+                    { "Grassy Plateaus 2", new Vector3(-390, -120, 648) },
+                    { "Grassy Plateaus 3", new Vector3(286, -72, 444) },
+                    { "Grassy Plateaus 4", new Vector3(-635, -50, -2) },
+                    { "Grassy Plateaus 5", new Vector3(-432, -90, -268) },
+                    { "Kelp Forest 1", new Vector3(-320, -57, 252) },
+                    { "Kelp Forest 2", new Vector3(65, -25, 385) },
+                    { "Mountains 1", new Vector3(701, -346, 1224) },
+                    { "Mountains 2", new Vector3(1057, -254, 1359) },
+                    { "Northwestern Mushroom Forest", new Vector3(-645, -120, 773) },
+                    { "Safe Shallows 1", new Vector3(-40, -14, -400) },
+                    { "Safe Shallows 2", new Vector3(366, -6, -203) },
+                    { "Sea Treader's Path", new Vector3(-1131, -166, -729) },
+                    { "Sparse Reef", new Vector3(-787, -208, -713) },
+                    { "Underwater Islands", new Vector3(-102, -179, 860) }
+                };
+                void Update()
+                {
+                    if (mouse_target_desc != "")
+                    {
+                        if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C))
+                        {
+                            Logging.Log("INSPECT GAME OBJECT: " + mouse_target_desc, ingame:false);
+                            string id = mouse_target_desc.Split(new char[] { ':' })[0];
+                            GUIUtility.systemCopyBuffer = id;
+                            copied_fade = 1.0f;
+                        }
+                    }
+                    copied_fade -= Time.deltaTime;
                 }
-            }
-            copied_fade -= Time.deltaTime;
-        }
-#endif
+        #endif*/
 
         void OnGUI()
         {
             Logging.TryUpdateLog();
-#if DEBUG
-            GUI.Box(new Rect(0, 0, Screen.width, 120), "");
-#endif
+/*#if DEBUG
+            GUI.Box(new Rect(0, 0, Screen.width, 140), "");
+#endif*/
             string ap_ver = "Archipelago v" + APState.AP_VERSION[0] + "." + APState.AP_VERSION[1] + "." + APState.AP_VERSION[2];
             if (APState.Session != null)
             {
@@ -98,11 +98,11 @@ namespace Archipelago
 
                 bool submit = Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return;
 
-                APState.ServerConnectInfo.host_name = GUI.TextField(new Rect(150 + 16 + 8, 36, 150, 20), 
+                APState.ServerConnectInfo.host_name = GUI.TextField(new Rect(150 + 16 + 8, 36, 150, 20),
                     APState.ServerConnectInfo.host_name);
-                APState.ServerConnectInfo.slot_name = GUI.TextField(new Rect(150 + 16 + 8, 56, 150, 20), 
+                APState.ServerConnectInfo.slot_name = GUI.TextField(new Rect(150 + 16 + 8, 56, 150, 20),
                     APState.ServerConnectInfo.slot_name);
-                APState.ServerConnectInfo.password = GUI.TextField(new Rect(150 + 16 + 8, 76, 150, 20), 
+                APState.ServerConnectInfo.password = GUI.TextField(new Rect(150 + 16 + 8, 76, 150, 20),
                     APState.ServerConnectInfo.password);
 
                 if (submit && Event.current.type == EventType.KeyDown)
@@ -118,121 +118,123 @@ namespace Archipelago
             }
             else if (APState.state == APState.State.InGame && APState.Session != null && Player.main != null)
             {
-                
+
                 if (APState.TrackedLocation != -1 && APState.TrackedMode != TrackerMode.Disabled)
                 {
                     string text = "Locations left: " + APState.TrackedLocationsCount;
                     if (APState.TrackedLocation != -1)
                     {
-                        text += ". Closest is " + (long)APState.TrackedDistance + " m (" 
+                        text += ". Closest is " + (long)APState.TrackedDistance + " m ("
                                 + (int)APState.TrackedAngle + "°) away";
                         text += ", named " + APState.TrackedLocationName;
                     }
-                    
+
                     GUI.Label(new Rect(16, 36, 1000, 20), text);
                 }
 
                 if (APState.TrackedFishCount > 0 && APState.TrackedMode != TrackerMode.Disabled)
                 {
-                    GUI.Label(new Rect(16, 56, 1000, 22), 
-                        "Fish left: "+APState.TrackedFishCount + ". Such as: "+APState.TrackedFish);
+                    GUI.Label(new Rect(16, 56, 1000, 22),
+                        "Fish left: " + APState.TrackedFishCount + ". Such as: " + APState.TrackedFish);
                 }
-                
+
                 if (PlayerNearStart())
                 {
-                    GUI.Label(new Rect(16, 76, 1000, 22), 
-                        "Goal: "+APState.Goal);
+                    GUI.Label(new Rect(16, 76, 1000, 22),
+                        "Goal: " + APState.Goal);
                     if (APState.SwimRule.Length == 0)
                     {
-                        GUI.Label(new Rect(16, 96, 1000, 22), 
-                            "No Swim Rule sent by Server. Assuming items_hard." + 
-                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth + 
+                        GUI.Label(new Rect(16, 96, 1000, 22),
+                            "No Swim Rule sent by Server. Assuming items_hard." +
+                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth +
                                                           TrackerThread.LogicVehicleDepth));
                     }
                     else
                     {
-                        GUI.Label(new Rect(16, 96, 1000, 22), 
-                            "Swim Rule: "+APState.SwimRule +
-                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth + 
-                                                          TrackerThread.LogicVehicleDepth) + 
-                            " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth + 
+                        GUI.Label(new Rect(16, 96, 1000, 22),
+                            "Swim Rule: " + APState.SwimRule +
+                            " Current Logical Depth: " + (TrackerThread.LogicSwimDepth +
+                                                          TrackerThread.LogicVehicleDepth) +
+                            " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth +
                             " (" + TrackerThread.LogicVehicle + ")");
                     }
+                    GUI.Label(new Rect(16, 116, 1000, 22),
+                        "Propulsion Cannon Logic: " + APState.PropulsionCannonLogic);
                 }
                 if (!APState.TrackerProcessing.IsAlive)
                 {
-                    GUI.Label(new Rect(16, 116, 1000, 22), 
+                    GUI.Label(new Rect(16, 136, 1000, 22),
                         "Error: Tracker Thread died. Tracker will not update.");
                 }
             }
 
-#if DEBUG
-            GUI.Label(new Rect(16, 16 + 20, Screen.width - 32, 50), ((copied_fade > 0.0f) ? "Copied!" : "Target: ") + mouse_target_desc);
+            /*#if DEBUG
+                        GUI.Label(new Rect(16, 16 + 20, Screen.width - 32, 50), ((copied_fade > 0.0f) ? "Copied!" : "Target: ") + mouse_target_desc);
 
-            if (APState.state != APState.State.Menu)
-            {
-                if (GUI.Button(new Rect(16, 16 + 25 + 8 + 25 + 8, 150, 25), "Activate Cheats"))
-                {
-                    DevConsole.SendConsoleCommand("nodamage");
-                    DevConsole.SendConsoleCommand("oxygen");
-                    DevConsole.SendConsoleCommand("item seaglide");
-                    DevConsole.SendConsoleCommand("item battery 10");
-                    DevConsole.SendConsoleCommand("fog");
-                    DevConsole.SendConsoleCommand("speed 3");
-                }
-                if (GUI.Button(new Rect(16 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Warp to Locations"))
-                {
-                    show_warps = !show_warps;
-                    if (show_warps) show_items = false;
-                }
-                if (GUI.Button(new Rect(16 + 150 + 8 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Items"))
-                {
-                    show_items = !show_items;
-                    if (show_items) show_warps = false;
-                }
+                        if (APState.state != APState.State.Menu)
+                        {
+                            if (GUI.Button(new Rect(16, 16 + 25 + 8 + 25 + 8, 150, 25), "Activate Cheats"))
+                            {
+                                DevConsole.SendConsoleCommand("nodamage");
+                                DevConsole.SendConsoleCommand("oxygen");
+                                DevConsole.SendConsoleCommand("item seaglide");
+                                DevConsole.SendConsoleCommand("item battery 10");
+                                DevConsole.SendConsoleCommand("fog");
+                                DevConsole.SendConsoleCommand("speed 3");
+                            }
+                            if (GUI.Button(new Rect(16 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Warp to Locations"))
+                            {
+                                show_warps = !show_warps;
+                                if (show_warps) show_items = false;
+                            }
+                            if (GUI.Button(new Rect(16 + 150 + 8 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Items"))
+                            {
+                                show_items = !show_items;
+                                if (show_items) show_warps = false;
+                            }
 
-                if (show_warps)
-                {
-                    int i = 0;
-                    int j = 125;
-                    foreach (var kv in WRECKS)
-                    {
-                        if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Key.ToString()))
-                        {
-                            string target = ((int)kv.Value.x).ToString() + " " +
-                                            ((int)kv.Value.y).ToString() + " " +
-                                            ((int)kv.Value.z + 50).ToString();
-                            DevConsole.SendConsoleCommand("warp " + target);
-                        }
-                        j += 30;
-                        if (j + 30 >= Screen.height)
-                        {
-                            j = 125;
-                            i += 200 + 16;
-                        }
-                    }
-                }
+                            if (show_warps)
+                            {
+                                int i = 0;
+                                int j = 125;
+                                foreach (var kv in WRECKS)
+                                {
+                                    if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Key.ToString()))
+                                    {
+                                        string target = ((int)kv.Value.x).ToString() + " " +
+                                                        ((int)kv.Value.y).ToString() + " " +
+                                                        ((int)kv.Value.z + 50).ToString();
+                                        DevConsole.SendConsoleCommand("warp " + target);
+                                    }
+                                    j += 30;
+                                    if (j + 30 >= Screen.height)
+                                    {
+                                        j = 125;
+                                        i += 200 + 16;
+                                    }
+                                }
+                            }
 
-                if (show_items)
-                {
-                    int i = 0;
-                    int j = 125;
-                    foreach (var kv in APState.ITEM_CODE_TO_TECHTYPE)
-                    {
-                        if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Value.ToString()))
-                        {
-                            APState.unlock(kv.Value);
+                            if (show_items)
+                            {
+                                int i = 0;
+                                int j = 125;
+                                foreach (var kv in APState.ITEM_CODE_TO_TECHTYPE)
+                                {
+                                    if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Value.ToString()))
+                                    {
+                                        APState.unlock(kv.Value);
+                                    }
+                                    j += 30;
+                                    if (j + 30 >= Screen.height)
+                                    {
+                                        j = 125;
+                                        i += 200 + 16;
+                                    }
+                                }
+                            }
                         }
-                        j += 30;
-                        if (j + 30 >= Screen.height)
-                        {
-                            j = 125;
-                            i += 200 + 16;
-                        }
-                    }
-                }
-            }
-#endif
+            #endif*/
         }
 
         public bool PlayerNearStart()
@@ -255,7 +257,7 @@ namespace Archipelago
             }
             return (podTransform.position - Player.main.transform.position).magnitude < 10f;
         }
-        
+
         private void Start()
         {
             RegisterCmds();
@@ -297,7 +299,7 @@ namespace Archipelago
                 text += (string)n.data[i];
                 if (i < n.data.Count - 1) text += " ";
             }
-            
+
             if (APState.Session != null && APState.Authenticated)
             {
                 var packet = new SayPacket();
@@ -312,7 +314,7 @@ namespace Archipelago
         private void OnConsoleCommand_silent(NotificationCenter.Notification n)
         {
             APState.Silent = !APState.Silent;
-            
+
             if (APState.Silent)
             {
                 Logging.Log("Muted Archipelago chat.");
@@ -345,7 +347,7 @@ namespace Archipelago
         {
             APState.ServerConnectInfo.death_link = !APState.ServerConnectInfo.death_link;
             APState.set_deathlink();
-            
+
             if (APState.ServerConnectInfo.death_link)
             {
                 Logging.Log("Enabled DeathLink.");
@@ -355,7 +357,7 @@ namespace Archipelago
                 Logging.Log("Disabled DeathLink.");
             }
         }
-        
+
         private void OnConsoleCommand_resync(NotificationCenter.Notification n)
         {
             if (APState.state == APState.State.InGame)
@@ -369,13 +371,13 @@ namespace Archipelago
                 Logging.Log("Cannot resync in menu.");
             }
         }
-        
+
         private void OnConsoleCommand_apdebug(NotificationCenter.Notification n)
         {
             //var loc = APState.TrackedLocation;
             //var loc_data = APState.LOCATIONS[loc];
             //DevConsole.SendConsoleCommand("warp "+(int)loc_data.Position.x+" "+(int)loc_data.Position.y+" "+(int)loc_data.Position.z);
-            
+
             //Debug.LogError("Analysis:");
             //string json = JsonConvert.SerializeObject(Player.main.pdaData.analysisTech);
             //Debug.LogError(json);
@@ -439,11 +441,11 @@ namespace Archipelago
     internal class BlueprintHandTarget_Start_Patch
     {
         // Using TechType.None gives 2 titanium we don't want that
-        [HarmonyPrefix] 
+        [HarmonyPrefix]
         public static void ReplaceDataboxContent(BlueprintHandTarget __instance)
         {
             // needs to be a unique not taken ID
-            __instance.unlockTechType = (TechType)__instance.transform.position.x+100000;
+            __instance.unlockTechType = (TechType)__instance.transform.position.x + 100000;
         }
     }
 
@@ -451,14 +453,14 @@ namespace Archipelago
     [HarmonyPatch("Start")]
     internal class DataboxSpawner_Start_Patch
     {
-        
+
         [HarmonyPrefix]
         public static bool AlwaysSpawn(DataboxSpawner __instance, ref IEnumerator __result)
         {
             __result = PatchedStart(__instance);
             return false;
         }
-        
+
         private static IEnumerator PatchedStart(DataboxSpawner __instance)
         {
             if (__instance.spawnTechType != 0)
@@ -547,13 +549,13 @@ namespace Archipelago
         public static void PrintCascade(List<KnownTech.AnalysisTech> ___analysisTech)
         {
             foreach (KnownTech.AnalysisTech tech in ___analysisTech)
-            { 
+            {
                 Debug.LogError(tech.techType + " -> " + JsonConvert.SerializeObject(tech.unlockTechTypes));
             }
         }
     }
 #endif
-    
+
     [HarmonyPatch(typeof(MainGameController))]
     [HarmonyPatch("LoadInitialInventoryAsync")]
     internal class MainGameController_LoadInitialInventoryAsync_Patch
@@ -580,7 +582,7 @@ namespace Archipelago
             return true;
         }
     }*/
-    
+
     [HarmonyPatch(typeof(UserStoragePC), "InitializeAsyncImpl")]
     internal class PlatformInitPatch
     {
@@ -588,7 +590,7 @@ namespace Archipelago
         [HarmonyPrefix]
         public static void InitializeOverride(object owner, object state)
         {
-            
+
             var storage = owner as UserStoragePC;
             var rawPath = storage.GetType().GetField("savePath",
                 BindingFlags.NonPublic | BindingFlags.Instance).GetValue(storage) as string;
@@ -608,7 +610,7 @@ namespace Archipelago
             }
         }
     }
-    
+
     [HarmonyPatch(typeof(SaveLoadManager.GameInfo))]
     [HarmonyPatch("SaveIntoCurrentSlot")]
     internal class GameInfo_SaveIntoCurrentSlot_Patch
@@ -617,11 +619,11 @@ namespace Archipelago
         public static void SaveIntoCurrentSlot(SaveLoadManager.GameInfo info)
         {
             var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(APState.ServerConnectInfo));
-            Platform.IO.File.WriteAllBytes(Platform.IO.Path.Combine(SaveLoadManager.GetTemporarySavePath(), 
+            Platform.IO.File.WriteAllBytes(Platform.IO.Path.Combine(SaveLoadManager.GetTemporarySavePath(),
                 "archipelago.json"), bytes);
         }
     }
-    
+
     [HarmonyPatch(typeof(SaveLoadManager))]
     [HarmonyPatch("SetCurrentSlot")]
     internal class SaveLoadManager_SetCurrentSlot_Patch
@@ -701,7 +703,7 @@ namespace Archipelago
                     }
                     catch (Exception e)
                     {
-                        Logging.LogError("archipelago_item_index error: " + e.Message, ingame:false);
+                        Logging.LogError("archipelago_item_index error: " + e.Message, ingame: false);
                     }
                 }
             }
@@ -817,24 +819,24 @@ namespace Archipelago
         }
     }
 
-#if DEBUG
-    [HarmonyPatch(typeof(GUIHand))]
-    [HarmonyPatch("OnUpdate")]
-    internal class GUIHand_OnUpdate_Patch
-    {
-        [HarmonyPostfix]
-        public static void OnUpdate(GUIHand __instance)
+    /*#if DEBUG
+        [HarmonyPatch(typeof(GUIHand))]
+        [HarmonyPatch("OnUpdate")]
+        internal class GUIHand_OnUpdate_Patch
         {
-            var active_target = __instance.GetActiveTarget();
-            if (active_target)
-                ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(active_target.gameObject);
-            else if (PDAScanner.scanTarget.gameObject)
-                ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(PDAScanner.scanTarget.gameObject);
-            else
-                ArchipelagoUI.mouse_target_desc = "";
+            [HarmonyPostfix]
+            public static void OnUpdate(GUIHand __instance)
+            {
+                var active_target = __instance.GetActiveTarget();
+                if (active_target)
+                    ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(active_target.gameObject);
+                else if (PDAScanner.scanTarget.gameObject)
+                    ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(PDAScanner.scanTarget.gameObject);
+                else
+                    ArchipelagoUI.mouse_target_desc = "";
+            }
         }
-    }
-#endif
+    #endif*/
 
     //[HarmonyPatch(typeof(LeakingRadiation))]
     //[HarmonyPatch("Start")]
@@ -848,7 +850,7 @@ namespace Archipelago
     //}
 
 
-    
+
     [HarmonyPatch(typeof(Story.UnlockBlueprintData))]
     [HarmonyPatch("Trigger")]
     internal class UnlockBlueprintData_Trigger_Patch
@@ -897,7 +899,7 @@ namespace Archipelago
             APState.DeathLinkKilling = false;
         }
     }
-    
+
     // Subnautica specific hooks
     // Ship start already exploded
     internal class EscapePod_StopIntroCinematic_Patch
@@ -930,7 +932,7 @@ namespace Archipelago
             return false;
         }
     }
-    
+
     internal class RocketConstructor_StartRocketConstruction_Patch
     {
         [HarmonyPrefix]
@@ -955,7 +957,7 @@ namespace Archipelago
             return true;
         }
     }
-    
+
     [HarmonyPatch(typeof(StoryGoalCustomEventHandler))]
     [HarmonyPatch("NotifyGoalComplete")]
     internal class StoryGoalCustomEventHandler_NotifyGoalComplete_Patch
@@ -967,6 +969,15 @@ namespace Archipelago
             {
                 APState.send_completion();
             }
+        }
+    }
+
+    internal class Player_Start_Patch
+    {
+        [HarmonyPostfix]
+        public static void Awake(Player __instance)
+        {
+            APSpawnHandler.AddHandlerAndSpawnBarriers();
         }
     }
 }

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -158,8 +158,17 @@ namespace Archipelago
                             " = " + TrackerThread.LogicSwimDepth + " (Swim) + " + TrackerThread.LogicVehicleDepth +
                             " (" + TrackerThread.LogicVehicle + ")");
                     }
-                    GUI.Label(new Rect(16, 116, 1000, 22),
+                    if (APState.PropulsionCannonLogic.Length == 0)
+                    {
+                        GUI.Label(new Rect(16, 96, 1000, 22),
+                            "No Propulsion Cannon Logic sent by Server. Assuming logicrequirement.");
+                    }
+                    else
+                    {
+                        GUI.Label(new Rect(16, 116, 1000, 22),
                         "Propulsion Cannon Logic: " + APState.PropulsionCannonLogic);
+                    }
+                    
                 }
                 if (!APState.TrackerProcessing.IsAlive)
                 {
@@ -977,7 +986,7 @@ namespace Archipelago
         [HarmonyPostfix]
         public static void Awake(Player __instance)
         {
-            APSpawnHandler.AddHandlerAndSpawnBarriers();
+            APSpawnHandler.CheckConditionsForSpawn();
         }
     }
 }

--- a/mod/Archipelago.cs
+++ b/mod/Archipelago.cs
@@ -19,53 +19,53 @@ namespace Archipelago
 {
     public class ArchipelagoUI : MonoBehaviour
     {
-        #if DEBUG
-                public static string mouse_target_desc = "";
-                private bool show_warps = false;
-                private bool show_items = false;
-                private float copied_fade = 0.0f;
+#if DEBUG
+        public static string mouse_target_desc = "";
+        private bool show_warps = false;
+        private bool show_items = false;
+        private float copied_fade = 0.0f;
 
-                public static Dictionary<string, Vector3> WRECKS = new Dictionary<string, Vector3>
+        public static Dictionary<string, Vector3> WRECKS = new Dictionary<string, Vector3>
+        {
+            { "Blood Kelp Trench 1", new Vector3(-1201, -324, -396) },
+            { "Bulb Zone 1", new Vector3(929, -198, 593) },
+            { "Bulb Zone 2", new Vector3(1309, -215, 570) },
+            { "Dunes 1", new Vector3(-1448, -332, 723) },
+            { "Dunes 2", new Vector3(-1632, -334, 83) },
+            { "Dunes 3", new Vector3(-1210, -217, 7) },
+            { "Grand Reef 1", new Vector3(-290, -222, -773) },
+            { "Grand Reef 2", new Vector3(-865, -430, -1390) },
+            { "Grassy Plateaus 1", new Vector3(-15, -96, -624) },
+            { "Grassy Plateaus 2", new Vector3(-390, -120, 648) },
+            { "Grassy Plateaus 3", new Vector3(286, -72, 444) },
+            { "Grassy Plateaus 4", new Vector3(-635, -50, -2) },
+            { "Grassy Plateaus 5", new Vector3(-432, -90, -268) },
+            { "Kelp Forest 1", new Vector3(-320, -57, 252) },
+            { "Kelp Forest 2", new Vector3(65, -25, 385) },
+            { "Mountains 1", new Vector3(701, -346, 1224) },
+            { "Mountains 2", new Vector3(1057, -254, 1359) },
+            { "Northwestern Mushroom Forest", new Vector3(-645, -120, 773) },
+            { "Safe Shallows 1", new Vector3(-40, -14, -400) },
+            { "Safe Shallows 2", new Vector3(366, -6, -203) },
+            { "Sea Treader's Path", new Vector3(-1131, -166, -729) },
+            { "Sparse Reef", new Vector3(-787, -208, -713) },
+            { "Underwater Islands", new Vector3(-102, -179, 860) }
+        };
+        void Update()
+        {
+            if (mouse_target_desc != "")
+            {
+                if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C))
                 {
-                    { "Blood Kelp Trench 1", new Vector3(-1201, -324, -396) },
-                    { "Bulb Zone 1", new Vector3(929, -198, 593) },
-                    { "Bulb Zone 2", new Vector3(1309, -215, 570) },
-                    { "Dunes 1", new Vector3(-1448, -332, 723) },
-                    { "Dunes 2", new Vector3(-1632, -334, 83) },
-                    { "Dunes 3", new Vector3(-1210, -217, 7) },
-                    { "Grand Reef 1", new Vector3(-290, -222, -773) },
-                    { "Grand Reef 2", new Vector3(-865, -430, -1390) },
-                    { "Grassy Plateaus 1", new Vector3(-15, -96, -624) },
-                    { "Grassy Plateaus 2", new Vector3(-390, -120, 648) },
-                    { "Grassy Plateaus 3", new Vector3(286, -72, 444) },
-                    { "Grassy Plateaus 4", new Vector3(-635, -50, -2) },
-                    { "Grassy Plateaus 5", new Vector3(-432, -90, -268) },
-                    { "Kelp Forest 1", new Vector3(-320, -57, 252) },
-                    { "Kelp Forest 2", new Vector3(65, -25, 385) },
-                    { "Mountains 1", new Vector3(701, -346, 1224) },
-                    { "Mountains 2", new Vector3(1057, -254, 1359) },
-                    { "Northwestern Mushroom Forest", new Vector3(-645, -120, 773) },
-                    { "Safe Shallows 1", new Vector3(-40, -14, -400) },
-                    { "Safe Shallows 2", new Vector3(366, -6, -203) },
-                    { "Sea Treader's Path", new Vector3(-1131, -166, -729) },
-                    { "Sparse Reef", new Vector3(-787, -208, -713) },
-                    { "Underwater Islands", new Vector3(-102, -179, 860) }
-                };
-                void Update()
-                {
-                    if (mouse_target_desc != "")
-                    {
-                        if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.C))
-                        {
-                            Logging.Log("INSPECT GAME OBJECT: " + mouse_target_desc, ingame:false);
-                            string id = mouse_target_desc.Split(new char[] { ':' })[0];
-                            GUIUtility.systemCopyBuffer = id;
-                            copied_fade = 1.0f;
-                        }
-                    }
-                    copied_fade -= Time.deltaTime;
+                    Logging.Log("INSPECT GAME OBJECT: " + mouse_target_desc, ingame:false);
+                    string id = mouse_target_desc.Split(new char[] { ':' })[0];
+                    GUIUtility.systemCopyBuffer = id;
+                    copied_fade = 1.0f;
                 }
-        #endif
+            }
+            copied_fade -= Time.deltaTime;
+        }
+#endif
 
         void OnGUI()
         {
@@ -180,73 +180,73 @@ namespace Archipelago
                 }
             }
 
-            #if DEBUG
-                        GUI.Label(new Rect(16, 16 + 20, Screen.width - 32, 50), ((copied_fade > 0.0f) ? "Copied!" : "Target: ") + mouse_target_desc);
+#if DEBUG
+            GUI.Label(new Rect(16, 16 + 20, Screen.width - 32, 50), ((copied_fade > 0.0f) ? "Copied!" : "Target: ") + mouse_target_desc);
 
-                        if (APState.state != APState.State.Menu)
+            if (APState.state != APState.State.Menu)
+            {
+                if (GUI.Button(new Rect(16, 16 + 25 + 8 + 25 + 8, 150, 25), "Activate Cheats"))
+                {
+                    DevConsole.SendConsoleCommand("nodamage");
+                    DevConsole.SendConsoleCommand("oxygen");
+                    DevConsole.SendConsoleCommand("item seaglide");
+                    DevConsole.SendConsoleCommand("item battery 10");
+                    DevConsole.SendConsoleCommand("fog");
+                    DevConsole.SendConsoleCommand("speed 3");
+                }
+                if (GUI.Button(new Rect(16 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Warp to Locations"))
+                {
+                    show_warps = !show_warps;
+                    if (show_warps) show_items = false;
+                }
+                if (GUI.Button(new Rect(16 + 150 + 8 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Items"))
+                {
+                    show_items = !show_items;
+                    if (show_items) show_warps = false;
+                }
+
+                if (show_warps)
+                {
+                    int i = 0;
+                    int j = 125;
+                    foreach (var kv in WRECKS)
+                    {
+                        if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Key.ToString()))
                         {
-                            if (GUI.Button(new Rect(16, 16 + 25 + 8 + 25 + 8, 150, 25), "Activate Cheats"))
-                            {
-                                DevConsole.SendConsoleCommand("nodamage");
-                                DevConsole.SendConsoleCommand("oxygen");
-                                DevConsole.SendConsoleCommand("item seaglide");
-                                DevConsole.SendConsoleCommand("item battery 10");
-                                DevConsole.SendConsoleCommand("fog");
-                                DevConsole.SendConsoleCommand("speed 3");
-                            }
-                            if (GUI.Button(new Rect(16 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Warp to Locations"))
-                            {
-                                show_warps = !show_warps;
-                                if (show_warps) show_items = false;
-                            }
-                            if (GUI.Button(new Rect(16 + 150 + 8 + 150 + 8, 16 + 25 + 8 + 25 + 8, 150, 25), "Items"))
-                            {
-                                show_items = !show_items;
-                                if (show_items) show_warps = false;
-                            }
-
-                            if (show_warps)
-                            {
-                                int i = 0;
-                                int j = 125;
-                                foreach (var kv in WRECKS)
-                                {
-                                    if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Key.ToString()))
-                                    {
-                                        string target = ((int)kv.Value.x).ToString() + " " +
-                                                        ((int)kv.Value.y).ToString() + " " +
-                                                        ((int)kv.Value.z + 50).ToString();
-                                        DevConsole.SendConsoleCommand("warp " + target);
-                                    }
-                                    j += 30;
-                                    if (j + 30 >= Screen.height)
-                                    {
-                                        j = 125;
-                                        i += 200 + 16;
-                                    }
-                                }
-                            }
-
-                            if (show_items)
-                            {
-                                int i = 0;
-                                int j = 125;
-                                foreach (var kv in APState.ITEM_CODE_TO_TECHTYPE)
-                                {
-                                    if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Value.ToString()))
-                                    {
-                                        APState.unlock(kv.Value);
-                                    }
-                                    j += 30;
-                                    if (j + 30 >= Screen.height)
-                                    {
-                                        j = 125;
-                                        i += 200 + 16;
-                                    }
-                                }
-                            }
+                            string target = ((int)kv.Value.x).ToString() + " " +
+                                            ((int)kv.Value.y).ToString() + " " +
+                                            ((int)kv.Value.z + 50).ToString();
+                            DevConsole.SendConsoleCommand("warp " + target);
                         }
-            #endif
+                        j += 30;
+                        if (j + 30 >= Screen.height)
+                        {
+                            j = 125;
+                            i += 200 + 16;
+                        }
+                    }
+                }
+
+                if (show_items)
+                {
+                    int i = 0;
+                    int j = 125;
+                    foreach (var kv in APState.ITEM_CODE_TO_TECHTYPE)
+                    {
+                        if (GUI.Button(new Rect(16 + i, j, 200, 25), kv.Value.ToString()))
+                        {
+                            APState.unlock(kv.Value);
+                        }
+                        j += 30;
+                        if (j + 30 >= Screen.height)
+                        {
+                            j = 125;
+                            i += 200 + 16;
+                        }
+                    }
+                }
+            }
+#endif
         }
 
         public bool PlayerNearStart()
@@ -831,24 +831,24 @@ namespace Archipelago
         }
     }
 
-    #if DEBUG
-        [HarmonyPatch(typeof(GUIHand))]
-        [HarmonyPatch("OnUpdate")]
-        internal class GUIHand_OnUpdate_Patch
+#if DEBUG
+    [HarmonyPatch(typeof(GUIHand))]
+    [HarmonyPatch("OnUpdate")]
+    internal class GUIHand_OnUpdate_Patch
+    {
+        [HarmonyPostfix]
+        public static void OnUpdate(GUIHand __instance)
         {
-            [HarmonyPostfix]
-            public static void OnUpdate(GUIHand __instance)
-            {
-                var active_target = __instance.GetActiveTarget();
-                if (active_target)
-                    ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(active_target.gameObject);
-                else if (PDAScanner.scanTarget.gameObject)
-                    ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(PDAScanner.scanTarget.gameObject);
-                else
-                    ArchipelagoUI.mouse_target_desc = "";
-            }
+            var active_target = __instance.GetActiveTarget();
+            if (active_target)
+                ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(active_target.gameObject);
+            else if (PDAScanner.scanTarget.gameObject)
+                ArchipelagoUI.mouse_target_desc = APState.InspectGameObject(PDAScanner.scanTarget.gameObject);
+            else
+                ArchipelagoUI.mouse_target_desc = "";
         }
-    #endif
+    }
+#endif
 
     //[HarmonyPatch(typeof(LeakingRadiation))]
     //[HarmonyPatch("Start")]

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,40 +9,40 @@
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Harmony">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.Harmony.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Preloader">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.Preloader.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.Preloader.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>special\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlatformIODefault">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\PlatformIODefault.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\PlatformIODefault.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Addressables">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Unity.Addressables.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Unity.Addressables.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="mkdir &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago&quot;&#xD;&#xA;COPY &quot;C:\Users\nelso\Desktop\Subnautica Modding\ArchipelagoSubnauticaModSrc\mod\bin\Debug\netstandard2.0\Archipelago.dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago&quot;&#xD;&#xA;&#xD;&#xA;COPY &quot;C:\Users\nelso\Desktop\Subnautica Modding\ArchipelagoSubnauticaModSrc\mod\bin\Debug\netstandard2.0\Archipelago.MultiClient.Net.dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\&quot;" />
+    <Exec Command="COPY $(TargetPath) D:\SteamLibrary\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\Archipelago.dll&#xD;&#xA;&#xD;&#xA;COPY $(TargetDir)Archipelago.MultiClient.Net.dll D:\SteamLibrary\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\Archipelago.MultiClient.Net.dll" />
   </Target>
 
 </Project>

--- a/mod/Archipelago.csproj
+++ b/mod/Archipelago.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,40 +9,40 @@
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Harmony">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.Harmony.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.Harmony.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Preloader">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\BepInEx\core\BepInEx.Preloader.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\core\BepInEx.Preloader.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>special\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlatformIODefault">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\PlatformIODefault.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\PlatformIODefault.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Addressables">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\Unity.Addressables.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\Unity.Addressables.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>D:\SteamLibrary\SteamApps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Subnautica\Subnautica_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="COPY $(TargetPath) D:\SteamLibrary\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\Archipelago.dll&#xD;&#xA;&#xD;&#xA;COPY $(TargetDir)Archipelago.MultiClient.Net.dll D:\SteamLibrary\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\Archipelago.MultiClient.Net.dll" />
+    <Exec Command="mkdir &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago&quot;&#xD;&#xA;COPY &quot;C:\Users\nelso\Desktop\Subnautica Modding\ArchipelagoSubnauticaModSrc\mod\bin\Debug\netstandard2.0\Archipelago.dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago&quot;&#xD;&#xA;&#xD;&#xA;COPY &quot;C:\Users\nelso\Desktop\Subnautica Modding\ArchipelagoSubnauticaModSrc\mod\bin\Debug\netstandard2.0\Archipelago.MultiClient.Net.dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Subnautica\BepInEx\plugins\Archipelago\&quot;" />
   </Target>
 
 </Project>

--- a/mod/ArchipelagoData.cs
+++ b/mod/ArchipelagoData.cs
@@ -98,4 +98,40 @@ public static class ArchipelagoData
         Debug.LogError("ItemCodeToItemType " + JsonConvert.SerializeObject(ItemCodeToItemType));
         Initialized = true;
     }
+
+    //Alters the location data stored in LogicDict to conform to selected choices
+    public static void UpdateLogicData()
+    {
+        if (APState.PropulsionCannonLogic == "no_requirement")
+        {
+            var LogicPatch = ReadJSON<Dictionary<int, List<long>>>("logic_revisions");
+            foreach (var logic_change in LogicPatch)
+            {
+                //Logic patches 1 and 2 remove propulsion cannon requirement from a location
+                if (logic_change.Key == 1 || logic_change.Key == 2) {
+                    foreach (var loc in logic_change.Value)
+                    {
+                        ArchipelagoData.LogicDict[TechType.PropulsionCannon].Remove(loc);
+                    }
+                }
+                //Logic patch 2 also adds laser cutter requirement
+                if (logic_change.Key == 2)
+                {
+                    foreach (var loc in logic_change.Value)
+                    {
+                        ArchipelagoData.LogicDict[TechType.LaserCutter].Add(loc);
+                    }
+                }
+            }
+            foreach (var logicloc in LogicDict[TechType.PropulsionCannon])
+            {
+                Logging.Log(logicloc.ToString());
+            }
+        }
+    }
+
+    public static void ChangeLogicEntry()
+    {
+ 
+    }
 }

--- a/mod/ArchipelagoData.cs
+++ b/mod/ArchipelagoData.cs
@@ -125,9 +125,4 @@ public static class ArchipelagoData
             }
         }
     }
-
-    public static void ChangeLogicEntry()
-    {
- 
-    }
 }

--- a/mod/ArchipelagoData.cs
+++ b/mod/ArchipelagoData.cs
@@ -123,10 +123,6 @@ public static class ArchipelagoData
                     }
                 }
             }
-            foreach (var logicloc in LogicDict[TechType.PropulsionCannon])
-            {
-                Logging.Log(logicloc.ToString());
-            }
         }
     }
 

--- a/mod/MainPatcher.cs
+++ b/mod/MainPatcher.cs
@@ -15,6 +15,7 @@ namespace Archipelago
         public static bool Zero;
         // Early Reflection to not fish for things later:
         public static Type SubnauticaEscapePod;
+        public static readonly BindingFlags all;
 
         private void Awake()
         {
@@ -65,6 +66,8 @@ namespace Archipelago
                 prefix: new HarmonyMethod(typeof(RocketConstructor_StartRocketConstruction_Patch).GetMethod("StartRocketConstruction")));
             harmony.Patch(typeof(LaunchRocket).GetMethod("SetLaunchStarted", BindingFlags.NonPublic | BindingFlags.Static),
                 prefix: new HarmonyMethod(typeof(LaunchRocket_SetLaunchStarted_Patch).GetMethod("SetLaunchStarted")));
+            harmony.Patch(typeof(Player).GetMethod("Awake"),
+                postfix: new HarmonyMethod(typeof(Player_Start_Patch).GetMethod("Awake")));
         }
     }
 }


### PR DESCRIPTION
## What is this fixing or adding?
This adds functionality for spawning crates in-game and altering tracker logic. These are used for added compatibility with a new APWorld option, PropulsionCannonLogic, which offers various options related to using the Propulsion Cannon to access the Aurora.

## How was this tested?

Object spawning and tracker alterations were tested individually. Compatibility was manually tested with all four PropulsionCannonLogic options. Since object spawning requires two hooks of varying order (valid connection and loaded world), strict logic was tested by connecting both before and after loading into game world. 